### PR TITLE
do not set alloc number if 1

### DIFF
--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -954,7 +954,9 @@ break_memory_alloc( long mem_alloc_order_num )
     unit_test::ut_detail::ignore_unused_variable_warning( mem_alloc_order_num );
 
 #ifdef BOOST_MS_CRT_BASED_DEBUG
-    _CrtSetBreakAlloc( mem_alloc_order_num );
+    // only set the value if one was supplied (do not use default used by UTF just as a indicator to enable leak detection)
+    if( mem_alloc_order_num > 1 )
+        _CrtSetBreakAlloc( mem_alloc_order_num );
 #endif // BOOST_MS_CRT_BASED_DEBUG
 }
 


### PR DESCRIPTION
Please (cherry-pick) merge this change to the "master" branch, so that it becomes part of the next boost release.

As of today, boost test always overrides the allocation number to break on. This is not a good idea if the user has already set a value from the debugger.

REF: http://lists.boost.org/Archives/boost/2013/09/206204.php