### PR TITLE
Make Boost.Test work with RTTI disabled (fixes #9228)

### DIFF
--- a/include/boost/test/execution_monitor.hpp
+++ b/include/boost/test/execution_monitor.hpp
@@ -261,7 +261,7 @@ public:
     template<typename ExceptionType>
     void        erase_exception_translator( boost::type<ExceptionType>* = 0 )
     {
-        m_custom_translators = m_custom_translators->erase<ExceptionType>( m_custom_translators );
+        m_custom_translators = m_custom_translators->template erase<ExceptionType>( m_custom_translators );
     }
 
 private:

--- a/include/boost/test/tree/test_case_template.hpp
+++ b/include/boost/test/tree/test_case_template.hpp
@@ -34,8 +34,13 @@
 #include <boost/type_traits/is_const.hpp>
 #include <boost/function/function0.hpp>
 
-// STL
+#ifndef BOOST_NO_RTTI
 #include <typeinfo> // for typeid
+#else
+#include <boost/current_function.hpp>
+#endif
+
+// STL
 #include <string>   // for std::string
 #include <list>     // for std::list
 
@@ -77,7 +82,11 @@ struct generate_test_case_4_type {
         std::string full_name;
         assign_op( full_name, m_test_case_name, 0 );
         full_name += '<';
-        full_name += typeid(TestType).name();
+#ifndef BOOST_NO_RTTI
+         full_name += typeid(TestType).name();
+#else
+        full_name += BOOST_CURRENT_FUNCTION;
+#endif
         if( boost::is_const<TestType>::value )
             full_name += " const";
         full_name += '>';


### PR DESCRIPTION
This commit fixes compilation on GCC with RTTI off
