### PR TITLE
Add missing va_end

### DIFF
--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -377,8 +377,10 @@ safe_execlp( char const* file, ... )
     va_start( args, file );
     while( !!(arg = va_arg( args, char const* )) ) {
         printf( "!! %s\n", arg );
-        if( !(*argv_it++ = copy_arg( work_buff, arg )) )
+        if( !(*argv_it++ = copy_arg( work_buff, arg )) ) {
+            va_end( args );
             return false;
+        }
     }
     va_end( args );
 


### PR DESCRIPTION
There is an unbalanced va_start / va_end sequence in debug.ipp

This fixes https://svn.boost.org/trac/boost/ticket/9779

Signed-off-by: Gregor Jasny gjasny@googlemail.com
