### PR TITLE
Fix unused variable warnings

### DIFF
--- a/include/boost/test/tools/assertion.hpp
+++ b/include/boost/test/tools/assertion.hpp
@@ -541,8 +541,8 @@ public:
 private:
     template<typename U>
     static void format_message( wrap_stringstream& ostr, U const& v )   { ostr << "[(bool)" << v << " is false]"; }
-    static void format_message( wrap_stringstream& ostr, bool v )       {}
-    static void format_message( wrap_stringstream& ostr, assertion_result const& v ) {}
+    static void format_message( wrap_stringstream& /*ostr*/, bool /*v*/ )       {}
+    static void format_message( wrap_stringstream& /*ostr*/, assertion_result const& /*v*/ ) {}
 
     // Data members
     T                           m_value;

--- a/include/boost/test/tools/detail/indirections.hpp
+++ b/include/boost/test/tools/detail/indirections.hpp
@@ -60,7 +60,7 @@ operator<<( assertion_evaluate_t<E> const& ae, T const& ) { return ae; }
 
 template<typename T>
 inline unit_test::lazy_ostream const&
-assertion_text( unit_test::lazy_ostream const& et, T const& m ) { return m; }
+assertion_text( unit_test::lazy_ostream const& /*et*/, T const& m ) { return m; }
 
 //____________________________________________________________________________//
 

--- a/include/boost/test/tools/detail/tolerance_manip.hpp
+++ b/include/boost/test/tools/detail/tolerance_manip.hpp
@@ -77,7 +77,7 @@ operator<<( unit_test::lazy_ostream const&, tolerance_manip<FPT> const& )   { re
 
 template<typename FPT>
 inline check_type
-operator<<( assertion_type const& at, tolerance_manip<FPT> const& )         { return CHECK_BUILT_ASSERTION; }
+operator<<( assertion_type const& /*at*/, tolerance_manip<FPT> const& )         { return CHECK_BUILT_ASSERTION; }
 
 //____________________________________________________________________________//
  

--- a/include/boost/test/utils/iterator/token_iterator.hpp
+++ b/include/boost/test/utils/iterator/token_iterator.hpp
@@ -151,7 +151,7 @@ struct token_assigner {
 template<>
 struct token_assigner<single_pass_traversal_tag> {
     template<typename Iterator, typename Token>
-    static void assign( Iterator b, Iterator e, Token& t )  {}
+    static void assign( Iterator /*b*/, Iterator /*e*/, Token& /*t*/ )  {}
 
     template<typename Iterator, typename Token>
     static void append_move( Iterator& b, Token& t )        { t += *b; ++b; }

--- a/include/boost/test/utils/named_params.hpp
+++ b/include/boost/test/utils/named_params.hpp
@@ -92,7 +92,7 @@ struct nil {
 
     // Visitation support
     template<typename Visitor>
-    void            apply_to( Visitor& V ) const {}
+    void            apply_to( Visitor& /*v*/ ) const {}
 
     static nil&     inst() { static nil s_inst; return s_inst; }
 private:


### PR DESCRIPTION
The warnings are also generated for:
boost/test/impl/execution_monitor.ipp:1329 -> enable( unsigned mask )
boost/test/impl/execution_monitor.ipp:1364 -> disable( unsigned mask )
but in this case the variable can't be commented out. boost::ignore_unused_variable_warning() defined in boost/concept_check.hpp could be used (I don't know it Test should depend on it), this function could be separated from ConceptCheck and put somewhere else first or similar function could be defined inside the Test.
