### PR TITLE
[winrt support] Disabling usage of some banned APIs for the Windows Runtime

### DIFF
--- a/include/boost/test/debug.hpp
+++ b/include/boost/test/debug.hpp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2006-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/debug.hpp
+++ b/include/boost/test/debug.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2006-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -31,6 +32,8 @@
 
 namespace boost {
 namespace debug {
+
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
 
 // ************************************************************************** //
 // **************  check if program is running under debugger  ************** //
@@ -70,6 +73,8 @@ std::string BOOST_TEST_DECL set_debugger( unit_test::const_string dbg_id, dbg_st
 // ************************************************************************** //
 
 bool BOOST_TEST_DECL attach_debugger( bool break_or_continue = true );
+
+#endif
 
 // ************************************************************************** //
 // **************   switch on/off detect memory leaks feature  ************** //

--- a/include/boost/test/detail/config.hpp
+++ b/include/boost/test/detail/config.hpp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/detail/config.hpp
+++ b/include/boost/test/detail/config.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +18,7 @@
 
 // Boost
 #include <boost/config.hpp> // compilers workarounds
+#include <boost/predef.h>
 #include <boost/detail/workaround.hpp>
 
 #if defined(_WIN32) && !defined(BOOST_DISABLE_WIN32) &&                  \
@@ -118,6 +120,14 @@ class type_info;
 
 #ifdef __PGI
 #define BOOST_PP_VARIADICS 1
+#endif
+
+// Used to turn on/off debugging support.
+#define BOOST_TEST_HAS_DEBUG_SUPPORT
+// Under Windows Runtime (WinRT) accessing registry, creating processes, etc..
+// are not supported so turn off debugging support.
+#if BOOST_PLAT_WINDOWS_RUNTIME
+#undef BOOST_TEST_HAS_DEBUG_SUPPORT
 #endif
 
 #endif // BOOST_TEST_CONFIG_HPP_071894GER

--- a/include/boost/test/impl/cpp_main.ipp
+++ b/include/boost/test/impl/cpp_main.ipp
@@ -1,6 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
 //  (C) Copyright Beman Dawes 1995-2001.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/impl/cpp_main.ipp
+++ b/include/boost/test/impl/cpp_main.ipp
@@ -1,5 +1,6 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
 //  (C) Copyright Beman Dawes 1995-2001.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -24,6 +25,7 @@
 // Boost
 #include <boost/cstdlib.hpp>    // for exit codes
 #include <boost/config.hpp>     // for workarounds
+#include <boost/predef/platform.h>
 
 // STL
 #include <iostream>
@@ -69,7 +71,11 @@ prg_exec_monitor_main( int (*cpp_main)( int argc, char* argv[] ), int argc, char
     int result = 0;
 
     try {
-        boost::unit_test::const_string p( std::getenv( "BOOST_TEST_CATCH_SYSTEM_ERRORS" ) );
+        boost::unit_test::const_string p;
+#if BOOST_PLAT_WINDOWS_DESKTOP
+        p = std::getenv( "BOOST_TEST_CATCH_SYSTEM_ERRORS" );
+#endif
+
         ::boost::execution_monitor ex_mon;
 
         ex_mon.p_catch_system_errors.value = p != "no";
@@ -102,7 +108,10 @@ prg_exec_monitor_main( int (*cpp_main)( int argc, char* argv[] ), int argc, char
         //  like the clutter.  Use an environment variable to avoid command
         //  line argument modifications; for use in production programs
         //  that's a no-no in some organizations.
-        ::boost::unit_test::const_string p( std::getenv( "BOOST_PRG_MON_CONFIRM" ) );
+        ::boost::unit_test::const_string p;
+#if BOOST_PLAT_WINDOWS_DESKTOP
+        p = std::getenv( "BOOST_PRG_MON_CONFIRM" );
+#endif
         if( p != "no" ) { 
             std::cerr << std::flush << "no errors detected" << std::endl; 
         }

--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2006-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -23,6 +23,7 @@
 
 #include <boost/test/debug.hpp>
 #include <boost/test/debug_config.hpp>
+#include <boost/predef/platform.h>
 
 // Implementation on Windows
 #if defined(_WIN32) && !defined(UNDER_CE) && !defined(BOOST_DISABLE_WIN32) // ******* WIN32
@@ -31,7 +32,9 @@
 
 // SYSTEM API
 #  include <windows.h>
+#  if !BOOST_PLAT_WINDOWS_RUNTIME
 #  include <winreg.h>
+#  endif
 #  include <cstdio>
 #  include <cstring>
 

--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2006-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -112,6 +113,8 @@ namespace boost {
 namespace debug {
 
 using unit_test::const_string;
+
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
 
 // ************************************************************************** //
 // **************                debug::info_t                 ************** //
@@ -913,6 +916,8 @@ attach_debugger( bool break_or_continue )
 
 //____________________________________________________________________________//
 
+#endif // BOOST_TEST_HAS_DEBUG_SUPPORT
+
 // ************************************************************************** //
 // **************   switch on/off detect memory leaks feature  ************** //
 // ************************************************************************** //
@@ -934,8 +939,7 @@ detect_memory_leaks( bool on_off, unit_test::const_string report_file )
         if( report_file.is_empty() )
             _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
         else {
-            HANDLE hreport_f = ::CreateFileA( report_file.begin(),
-                                              GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+            HANDLE hreport_f = ::fopen(report_file.begin(), "w");
             _CrtSetReportFile(_CRT_WARN, hreport_f );
         }
     }

--- a/include/boost/test/impl/exception_safety.ipp
+++ b/include/boost/test/impl/exception_safety.ipp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/impl/exception_safety.ipp
+++ b/include/boost/test/impl/exception_safety.ipp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -388,8 +389,10 @@ exception_safety_tester::assertion_result( unit_test::assertion_result ar )
 void
 exception_safety_tester::failure_point()
 {
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
     if( m_exec_path_counter == m_break_exec_path )
         debug::debugger_break();
+#endif
     
     throw unique_exception();
 }

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  (C) Copyright Beman Dawes and Ullrich Koethe 1995-2001.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  (C) Copyright Beman Dawes and Ullrich Koethe 1995-2001.
 //  Use, modification, and distribution are subject to the
 //  Boost Software License, Version 1.0. (See accompanying file
@@ -803,7 +804,12 @@ static void boost_execution_monitor_jumping_signal_handler( int sig, siginfo_t* 
 
 static void boost_execution_monitor_attaching_signal_handler( int sig, siginfo_t* info, void* context )
 {
-    if( !debug::attach_debugger( false ) )
+    bool successfully_attached = false;
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
+    successfully_attached = debug::attach_debugger( false );
+#endif
+
+    if( !successfully_attached )
         boost_execution_monitor_jumping_signal_handler( sig, info, context );
 
     // debugger attached; it will handle the signal
@@ -930,6 +936,7 @@ system_signal_exception::operator()( unsigned int id, _EXCEPTION_POINTERS* exps 
         }
     }
 
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
     if( !!m_em->p_auto_start_dbg && debug::attach_debugger( false ) ) {
         m_em->p_catch_system_errors.value = false;
 #if BOOST_WORKAROUND( BOOST_MSVC, <= 1310)
@@ -937,6 +944,7 @@ system_signal_exception::operator()( unsigned int id, _EXCEPTION_POINTERS* exps 
 #endif
         return EXCEPTION_CONTINUE_EXECUTION;
     }
+#endif
 
     m_se_id = id;
     if( m_se_id == EXCEPTION_ACCESS_VIOLATION && exps->ExceptionRecord->NumberParameters == 2 ) {
@@ -1173,9 +1181,11 @@ execution_monitor::execution_monitor()
 int
 execution_monitor::execute( boost::function<int ()> const& F )
 {
+#ifdef BOOST_TEST_HAS_DEBUG_SUPPORT
     if( debug::under_debugger() )
         p_catch_system_errors.value = false;
-
+#endif
+        
     try {
         detail::fpe_except_guard G( p_detect_fp_exceptions );
         unit_test::ut_detail::ignore_unused_variable_warning( G );

--- a/include/boost/test/impl/unit_test_parameters.ipp
+++ b/include/boost/test/impl/unit_test_parameters.ipp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -18,6 +19,8 @@
 #ifndef BOOST_TEST_UNIT_TEST_PARAMETERS_IPP_012205GER
 #define BOOST_TEST_UNIT_TEST_PARAMETERS_IPP_012205GER
 
+#include <boost/predef/platform.h>
+
 // Boost.Test
 
 #include <boost/test/unit_test_parameters.hpp>
@@ -36,9 +39,11 @@ namespace rt  = boost::runtime;
 namespace cla = rt::cla;
 
 #ifndef UNDER_CE
+#if BOOST_PLAT_WINDOWS_DESKTOP
 #include <boost/test/utils/runtime/env/variable.hpp>
 
 namespace env = rt::env;
+#endif
 #endif
 
 // Boost
@@ -244,7 +249,9 @@ retrieve_parameter( const_string parameter_name, cla::parser const& s_cla_parser
     boost::optional<T> v;
 
 #ifndef UNDER_CE
+#if BOOST_PLAT_WINDOWS_DESKTOP
     env::get( parameter_2_env_var(parameter_name), v );
+#endif
 #endif
 
     if( v )

--- a/include/boost/test/impl/unit_test_parameters.ipp
+++ b/include/boost/test/impl/unit_test_parameters.ipp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2001-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/impl/unit_test_parameters.ipp
+++ b/include/boost/test/impl/unit_test_parameters.ipp
@@ -19,10 +19,7 @@
 #ifndef BOOST_TEST_UNIT_TEST_PARAMETERS_IPP_012205GER
 #define BOOST_TEST_UNIT_TEST_PARAMETERS_IPP_012205GER
 
-#include <boost/predef/platform.h>
-
 // Boost.Test
-
 #include <boost/test/unit_test_parameters.hpp>
 #include <boost/test/utils/basic_cstring/basic_cstring.hpp>
 #include <boost/test/utils/basic_cstring/compare.hpp>
@@ -35,6 +32,19 @@
 #include <boost/test/utils/runtime/cla/dual_name_parameter.hpp>
 #include <boost/test/utils/runtime/cla/parser.hpp>
 
+// Boost
+#include <boost/config.hpp>
+#include <boost/predef/platform.h>
+#include <boost/test/detail/suppress_warnings.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/test/detail/enable_warnings.hpp>
+
+// STL
+#include <map>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+
 namespace rt  = boost::runtime;
 namespace cla = rt::cla;
 
@@ -45,18 +55,6 @@ namespace cla = rt::cla;
 namespace env = rt::env;
 #endif
 #endif
-
-// Boost
-#include <boost/config.hpp>
-#include <boost/test/detail/suppress_warnings.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/test/detail/enable_warnings.hpp>
-
-// STL
-#include <map>
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
 
 #include <boost/test/detail/suppress_warnings.hpp>
 

--- a/include/boost/test/utils/runtime/config.hpp
+++ b/include/boost/test/utils/runtime/config.hpp
@@ -1,5 +1,4 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
-//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/test/utils/runtime/config.hpp
+++ b/include/boost/test/utils/runtime/config.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +18,7 @@
 
 // Boost
 #include <boost/config.hpp>
+#include <boost/predef/platform.h>
 #ifdef BOOST_MSVC
 # pragma warning(disable: 4511) // copy constructor could not be generated
 # pragma warning(disable: 4512) // assignment operator could not be generated
@@ -77,6 +79,7 @@ extern "C" int putenv( const char * );
 #endif
 
 #ifndef UNDER_CE
+#if BOOST_PLAT_WINDOWS_DESKTOP
 #if defined(__COMO__) && 0
 inline void
 putenv_impl( cstring name, cstring value )
@@ -100,6 +103,7 @@ putenv_impl( cstring name, cstring value )
 }
 #endif
 #endif
+#endif
 
 #ifdef BOOST_MSVC 
 #pragma warning(pop) 
@@ -107,8 +111,10 @@ putenv_impl( cstring name, cstring value )
 
 #define BOOST_RT_PARAM_LITERAL( l ) l
 #define BOOST_RT_PARAM_CSTRING_LITERAL( l ) cstring( l, sizeof( l ) - 1 )
+#if BOOST_PLAT_WINDOWS_DESKTOP
 #define BOOST_RT_PARAM_GETENV getenv
 #define BOOST_RT_PARAM_PUTENV ::boost::BOOST_RT_PARAM_NAMESPACE::putenv_impl
+#endif
 #define BOOST_RT_PARAM_EXCEPTION_INHERIT_STD
 
 //____________________________________________________________________________//
@@ -123,6 +129,7 @@ typedef wrap_wstringstream                                      format_stream;
 typedef std::wostream                                           out_stream;
 
 #ifndef UNDER_CE
+#if BOOST_PLAT_WINDOWS_DESKTOP
 inline void
 putenv_impl( cstring name, cstring value )
 {
@@ -136,11 +143,14 @@ putenv_impl( cstring name, cstring value )
     wputenv( const_cast<wchar_t*>( fs.str().c_str() ) );
 }
 #endif
+#endif
 
 #define BOOST_RT_PARAM_LITERAL( l ) L ## l
 #define BOOST_RT_PARAM_CSTRING_LITERAL( l ) cstring( L ## l, sizeof( L ## l )/sizeof(wchar_t) - 1 )
+#if BOOST_PLAT_WINDOWS_DESKTOP
 #define BOOST_RT_PARAM_GETENV wgetenv
 #define BOOST_RT_PARAM_PUTENV putenv_impl
+#endif
 
 #  endif
 #endif

--- a/include/boost/test/utils/runtime/env/environment.hpp
+++ b/include/boost/test/utils/runtime/env/environment.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -15,8 +16,14 @@
 #ifndef BOOST_RT_ENV_ENVIRONMENT_HPP_062604GER
 #define BOOST_RT_ENV_ENVIRONMENT_HPP_062604GER
 
+#include <boost/predef/platform.h>
+
 #ifdef UNDER_CE
 #error Windows CE does not support environment variables.
+#endif
+
+#if BOOST_PLAT_WINDOWS_RUNTIME
+#error Windows Runtime does not support environment variables.
 #endif
 
 // Boost.Runtime.Parameter

--- a/include/boost/test/utils/runtime/env/variable.hpp
+++ b/include/boost/test/utils/runtime/env/variable.hpp
@@ -1,4 +1,5 @@
 //  (C) Copyright Gennadiy Rozental 2005-2012.
+//  (C) Copyright Microsoft Corporation 2014.
 //  Distributed under the Boost Software License, Version 1.0.
 //  (See accompanying file LICENSE_1_0.txt or copy at 
 //  http://www.boost.org/LICENSE_1_0.txt)
@@ -15,8 +16,14 @@
 #ifndef BOOST_RT_ENV_VARIABLE_HPP_062604GER
 #define BOOST_RT_ENV_VARIABLE_HPP_062604GER
 
+#include <boost/predef/platform.h>
+
 #ifdef UNDER_CE
 #error Windows CE does not support environment variables.
+#endif
+
+#if BOOST_PLAT_WINDOWS_RUNTIME
+#error Windows Runtime does not support environment variables.
 #endif
 
 // Boost.Runtime.Parameter


### PR DESCRIPTION
Adding a macro for turning on/off for debugger support. Attaching a debugger is disabled if running tests for the Windows Runtime.

Disabled some usage of environment variables, which aren't avaliable, when under the Windows Runtime.

Replaced one usage of CreateFileA, which isn't allow in the Windows Runtime with fopen.