### PR TITLE
Replace unsigned int with std::list<>::size_type to eliminate warnings i...

### DIFF
--- a/include/boost/test/utils/runtime/cla/parser.hpp
+++ b/include/boost/test/utils/runtime/cla/parser.hpp
@@ -76,6 +76,7 @@ private:
 class parser {
 public:
     typedef std::list<parameter_ptr>::const_iterator param_iterator;
+    typedef std::list<parameter_ptr>::size_type param_size_type;
 
     // Constructor
     explicit            parser( cstring program_name = cstring() );
@@ -100,7 +101,7 @@ public:
     // parameters access
     param_iterator      first_param() const;
     param_iterator      last_param() const;
-    unsigned            num_params() const  { return m_parameters.size(); }
+    param_size_type     num_params() const  { return m_parameters.size(); }
     void                reset();
 
     // arguments access


### PR DESCRIPTION
...n MSVCx64
