### PR TITLE
Fix doc spelling, warnings about switch and member hiding

### DIFF
--- a/doc/html/utf/user-guide/test-output/BOOST_TEST_CHECKPOINT.html
+++ b/doc/html/utf/user-guide/test-output/BOOST_TEST_CHECKPOINT.html
@@ -36,7 +36,7 @@
     macro signature is as follows:
    </p>
 <pre class="inline-synopsis">
-<a name="BOOST_TEST_CHECKPOINT"></a>BOOST_TEST_CHECKPOINT(<span class="emphasis"><em>checkoint_message</em></span>)</pre>
+<a name="BOOST_TEST_CHECKPOINT"></a>BOOST_TEST_CHECKPOINT(<span class="emphasis"><em>checkpoint_message</em></span>)</pre>
 <p class="first-line-indented">
     The message formatted at the checkpoint position is saved and reported by the exception logging functions (if any
     occurs). Similarly to the <code class="computeroutput"><a class="link" href="BOOST_TEST_MESSAGE.html#BOOST_TEST_MESSAGE">BOOST_TEST_MESSAGE</a></code> the message can be formatted from any standard

--- a/doc/src/utf.user-guide.test-output.xml
+++ b/doc/src/utf.user-guide.test-output.xml
@@ -252,7 +252,7 @@
 
    <inline-synopsis>
     <macro name="BOOST_TEST_CHECKPOINT" kind="functionlike">
-     <macro-parameter name="checkoint_message"/>
+     <macro-parameter name="checkpoint_message"/>
     </macro>
    </inline-synopsis>
 

--- a/include/boost/test/tree/fixture.hpp
+++ b/include/boost/test/tree/fixture.hpp
@@ -90,9 +90,9 @@ private:
 class function_based_fixture : public test_unit_fixture { 
 public:
     // Constructor
-    function_based_fixture( boost::function<void ()> const& setup, boost::function<void ()> const& teardown )
-    : m_setup( setup )
-    , m_teardown( teardown )
+    function_based_fixture( boost::function<void ()> const& setup_, boost::function<void ()> const& teardown_ )
+    : m_setup( setup_ )
+    , m_teardown( teardown_ )
     {
     }
 

--- a/include/boost/test/tree/observer.hpp
+++ b/include/boost/test/tree/observer.hpp
@@ -49,6 +49,7 @@ public:
         case AR_PASSED: assertion_result( true ); break;
         case AR_FAILED: assertion_result( false ); break;
         case AR_TRIGGERED: break;
+        default: break;
         }
     }
     virtual void    exception_caught( execution_exception const& ) {}

--- a/include/boost/test/utils/runtime/cla/parser.hpp
+++ b/include/boost/test/utils/runtime/cla/parser.hpp
@@ -100,7 +100,7 @@ public:
     // parameters access
     param_iterator      first_param() const;
     param_iterator      last_param() const;
-    unsigned            num_params() const  { return m_parameters.size(); }
+    std::size_t         num_params() const  { return m_parameters.size(); }
     void                reset();
 
     // arguments access


### PR DESCRIPTION
Fix small warnings about not all possibilities in a switch and an argument name hiding member variable.
Fix spelling in doc.
