### PR TITLE
Fix incomplete BOOST_TEST_DONT_PRINT_LOG_VALUE when using BOOST_TEST_DON...

### DIFF
--- a/include/boost/test/tools/detail/print_helper.hpp
+++ b/include/boost/test/tools/detail/print_helper.hpp
@@ -182,13 +182,22 @@ operator<<( std::ostream& ostr, print_helper_t<T> const& ph )
 // **************       BOOST_TEST_DONT_PRINT_LOG_VALUE        ************** //
 // ************************************************************************** //
 
-#define BOOST_TEST_DONT_PRINT_LOG_VALUE( the_type )         \
-namespace boost{ namespace test_tools{ namespace tt_detail{ \
-template<>                                                  \
-struct print_log_value<the_type > {                         \
-    void    operator()( std::ostream&, the_type const& ) {} \
-};                                                          \
-}}}                                                         \
+#define BOOST_TEST_DONT_PRINT_LOG_VALUE( the_type )                 \
+namespace boost {                                                   \
+                                                                    \
+template <typename CharT>                                           \
+inline basic_wrap_stringstream<CharT>&                              \
+operator<<( basic_wrap_stringstream<CharT>& targ, the_type const& ) \
+{                                                                   \
+    return targ;                                                    \
+}                                                                   \
+                                                                    \
+namespace test_tools{ namespace tt_detail{                          \
+template<>                                                          \
+struct print_log_value<the_type > {                                 \
+    void    operator()( std::ostream&, the_type const& ) {}         \
+};                                                                  \
+}}}                                                                 \
 /**/
 
 } // namespace test_tools

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -91,6 +91,7 @@ test-suite "unit_test_framework_test"
           [ test-btl-lib run : test_datasets_cxx11          : boost_unit_test_framework : : [ glob test_datasets_src/*.cpp ] : : <toolset>gcc:<cxxflags>-std=gnu++0x ]
           # [ test-btl-lib run : config_file_iterator_test    : boost_unit_test_framework/<link>static ]
           # [ test-btl-lib run : config_file_test             : boost_unit_test_framework/<link>static ]
+          [ test-btl-lib run : test_dont_print_log_value    : boost_unit_test_framework ]
         ;
 
 test-suite "multithreaded_test"

--- a/test/test_dont_print_log_value.cpp
+++ b/test/test_dont_print_log_value.cpp
@@ -1,0 +1,49 @@
+//  (C) Copyright Marek Kurdej 2014.
+//  Distributed under the Boost Software License, Version 1.0.
+//  (See accompanying file LICENSE_1_0.txt or copy at 
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/test for the library home page.
+//
+//  File        : $RCSfile$
+//
+//  Version     : $Revision$
+//
+//  Description : BOOST_TEST_DONT_PRINT_LOG_VALUE unit test
+// *****************************************************************************
+
+// Boost.Test
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+// STL
+#include <vector>
+
+struct MyClass
+{
+    bool operator==(MyClass const&) const
+    {
+        return true;
+    }
+    
+    bool operator!=(MyClass const&) const
+    {
+        return false;
+    }    
+};
+
+typedef ::std::vector<MyClass> MyClassVec;
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(MyClass)
+
+BOOST_AUTO_TEST_CASE(single_object)
+{
+    MyClass actual, expected;
+    BOOST_CHECK_EQUAL(actual, expected);
+}
+
+BOOST_AUTO_TEST_CASE(collection_of_objects)
+{
+    MyClassVec actual, expected;
+    BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+}


### PR DESCRIPTION
When we use a user-defined error without overloaded operator<<(std::ostream&, T const&), we have to use BOOST_TEST_DONT_PRINT_LOG_VALUE in order to prevent UTF to print output to log.
BOOST_TEST_DONT_PRINT_LOG_VALUE works correctly only if you use macros like BOOST_CHECK_EQUAL.
However, BOOST_CHECK_EQUAL_COLLECTIONS provokes compile-time error.

Fixes https://svn.boost.org/trac/boost/ticket/9390.

Error messages:
// MSVC:
//  ./boost/test/utils/wrap_stringstream.hpp(66) : error C2679: binary '<<' : no operator found which takes a right-hand operand of type 'const MyClass' (or there is no acceptable conversion)
// GCC:
// ./boost/test/utils/wrap_stringstream.hpp:66:19: error: no match for 'operator<<' (operand types are 'boost::basic_wrap_stringstream<char>::wrapped_stream {aka std::basic_ostringstream<char>}' and 'const MyClass')
//     targ.stream() << t;
