### PR TITLE
Tests & fixes for Boost.Test UTF command-line parsing.

### DIFF
--- a/include/boost/test/utils/runtime/cla/argv_traverser.hpp
+++ b/include/boost/test/utils/runtime/cla/argv_traverser.hpp
@@ -71,6 +71,9 @@ public:
     bool            handle_mismatch();
 
 private:
+    void            next_token( bool initial_token );
+
+private:
     // Data members
     dstring                 m_buffer;
     cstring                 m_work_buffer;

--- a/include/boost/test/utils/runtime/cla/argv_traverser.ipp
+++ b/include/boost/test/utils/runtime/cla/argv_traverser.ipp
@@ -64,7 +64,7 @@ argv_traverser::init( int argc, char_type** argv )
 
     BOOST_RT_PARAM_TRACE( "Input buffer: " << m_buffer );
 
-    next_token();
+    next_token( true );
 }
 
 //____________________________________________________________________________//
@@ -96,13 +96,21 @@ argv_traverser::token() const
 BOOST_RT_PARAM_INLINE void
 argv_traverser::next_token()
 {
+    return next_token( false );
+}
+
+//____________________________________________________________________________//
+
+BOOST_RT_PARAM_INLINE void
+argv_traverser::next_token( bool initial_token )
+{
     if( m_work_buffer.is_empty() )
         return;
 
     m_work_buffer.trim_left( m_token.size() ); // skip remainder of current token
 
-    if( m_work_buffer.size() != m_buffer.size() ) // !! is there a better way to identify first token
-        m_work_buffer.trim_left( 1 ); // skip separator if not first token;
+    if( !initial_token )
+        m_work_buffer.trim_left( 1 ); // skip separator
 
     m_token.assign( m_work_buffer.begin(),
                     std::find( m_work_buffer.begin(), m_work_buffer.end(), p_separator ) );

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -89,6 +89,7 @@ test-suite "unit_test_framework_test"
           [ test-btl-lib run : test_assertion_construction  : boost_unit_test_framework/<link>static ]
           [ test-btl-lib run : test_datasets                : boost_unit_test_framework : : [ glob test_datasets_src/*.cpp ] : ]
           [ test-btl-lib run : test_datasets_cxx11          : boost_unit_test_framework : : [ glob test_datasets_src/*.cpp ] : : <toolset>gcc:<cxxflags>-std=gnu++0x ]
+          [ test-btl-lib run : test_cla_parsing             : boost_unit_test_framework/<link>static ]
           # [ test-btl-lib run : config_file_iterator_test    : boost_unit_test_framework/<link>static ]
           # [ test-btl-lib run : config_file_test             : boost_unit_test_framework/<link>static ]
         ;

--- a/test/test_cla_parsing.cpp
+++ b/test/test_cla_parsing.cpp
@@ -11,6 +11,14 @@
 //
 //  Description : unit test for UTF command-line argument parsing
 // ***************************************************************************
+// Tests marked with <REGRESSION #1> are regression tests against a command-line
+// argument parsing implementation bug in Boost.Test causing a buffer overrun
+// and thus triggering access-violation/segfault errors when one of the
+// arguments starts with a space or the leading argument is empty.
+//
+// Test cases marked with <UNDESIRABLE RESULT #1> do not check the command-line
+// arguments after they are processed by UTF because the current UTF
+// implementation seems to mess them up.
 
 // disable MSVC warnings about std::strcpy() being unsafe
 #ifdef _MSC_VER
@@ -106,6 +114,14 @@ private:
 
 BOOST_AUTO_TEST_SUITE(empty_argument)
 
+    //<REGRESSION #1>
+    BOOST_AUTO_TEST_CASE(test_initial)
+    {
+        char * argv[] = {"a.exe", "", "x"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        arg_checker.check_unchanged();
+    }
+
     BOOST_AUTO_TEST_CASE(test_inside)
     {
         char * argv[] = {"a.exe", "x", "", "y"};
@@ -118,6 +134,36 @@ BOOST_AUTO_TEST_SUITE(empty_argument)
         char * argv[] = {"a.exe", "x", "", "", "y"};
         ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
         arg_checker.check_unchanged();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//____________________________________________________________________________//
+
+BOOST_AUTO_TEST_SUITE(argument_starting_with_space)
+
+    //<REGRESSION #1>
+    BOOST_AUTO_TEST_CASE(test_only)
+    {
+        char * argv[] = {"a.exe", " x"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        // <UNDESIRABLE RESULT #1> - should not split on embedded spaces
+    }
+
+    //<REGRESSION #1>
+    BOOST_AUTO_TEST_CASE(test_initial)
+    {
+        char * argv[] = {"a.exe", " x", "y"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        // <UNDESIRABLE RESULT #1> - should not split on embedded spaces
+    }
+
+    //<REGRESSION #1>
+    BOOST_AUTO_TEST_CASE(test_non_initial)
+    {
+        char * argv[] = {"a.exe", "x", " y"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        // <UNDESIRABLE RESULT #1> - should not split on embedded spaces
     }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_cla_parsing.cpp
+++ b/test/test_cla_parsing.cpp
@@ -1,0 +1,147 @@
+//  (C) Copyright Jurko Gospodnetić 2014.
+//  Distributed under the Boost Software License, Version 1.0.
+//  (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/test for the library home page.
+//
+//  File        : $RCSfile$
+//
+//  Version     : $Revision$
+//
+//  Description : unit test for UTF command-line argument parsing
+// ***************************************************************************
+
+// disable MSVC warnings about std::strcpy() being unsafe
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+
+// Boost.Test
+#define BOOST_TEST_MODULE Boost.Test command-line argument parsing test
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_parameters.hpp>
+
+#include <cstring>
+#include <vector>
+
+namespace utf = boost::unit_test;
+
+// Test utility class for checking UTF command-line argument processing results.
+//
+class ArgChecker
+{
+public:
+    ArgChecker(int const input_data_count, char const * const input_data[])
+        :
+        argc_(input_data_count)
+    {
+        BOOST_REQUIRE_GT(input_data_count, 0);
+        BOOST_REQUIRE(input_data);
+
+        // calculate required argument data size and offsets
+        std::vector<std::size_t> data_offset(input_data_count);
+        std::size_t data_size = 0;
+        for (int i = 0; i < input_data_count; ++i) {
+            data_offset[i] = data_size;
+            data_size += strlen(input_data[i]) + 1;
+        }
+
+        // prepare argument data (data + argv)
+        data_.resize(data_size);
+        argv_.resize(input_data_count + 1);
+        for (int i = 0; i < input_data_count; ++i) {
+            argv_[i] = &data_[data_offset[i]];
+            std::strcpy(argv_[i], input_data[i]);
+        }
+
+        // argv[argc] must be NULL according to ANSI C standard
+        argv_[argc_] = NULL;
+
+        // save original data & argv content
+        saved_argc_ = argc_;
+        saved_data_ = data_;
+        saved_argv_ = argv_;
+
+        // run actual UTF command-line argument processing
+        utf::runtime_config::init(argc_, &argv_[0]);
+    }
+
+    // Check that the command-line arguments have not been changed while
+    // processed by UTF. UTF may replace them with copies, but their content
+    // must remain the same.
+    //
+    void check_unchanged() const
+    {
+        check(saved_argc_, &saved_argv_[0]);
+    }
+
+    // Check that the command-line arguments left behind after being processed
+    // by UTF.
+    //
+    void check(int const expected_argc,
+        char const * const expected_argv[]) const
+    {
+        BOOST_CHECK(saved_data_ == data_);  // input data unchanged
+        BOOST_CHECK_EQUAL(expected_argc, argc_);
+        if (expected_argc == argc_)
+            for (int i = 0; i < argc_; ++i)
+                BOOST_CHECK(!std::strcmp(expected_argv[i], argv_[i]));
+    }
+
+private:
+    ArgChecker(ArgChecker const &);
+    void operator=(ArgChecker const &) const;
+
+private:
+    int argc_;
+    std::vector<char> data_;
+    std::vector<char *> argv_;
+    int saved_argc_;
+    std::vector<char> saved_data_;
+    std::vector<char *> saved_argv_;
+};
+
+//____________________________________________________________________________//
+
+BOOST_AUTO_TEST_SUITE(empty_argument)
+
+    BOOST_AUTO_TEST_CASE(test_inside)
+    {
+        char * argv[] = {"a.exe", "x", "", "y"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        arg_checker.check_unchanged();
+    }
+
+    BOOST_AUTO_TEST_CASE(test_inside_sequence)
+    {
+        char * argv[] = {"a.exe", "x", "", "", "y"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        arg_checker.check_unchanged();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//____________________________________________________________________________//
+
+BOOST_AUTO_TEST_SUITE(non_empty_arguments_without_spaces)
+
+    BOOST_AUTO_TEST_CASE(test_one)
+    {
+        char const * const argv[] = {"a.exe", "x"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        arg_checker.check_unchanged();
+    }
+
+    BOOST_AUTO_TEST_CASE(test_multiple)
+    {
+        char * argv[] = {"a.exe", "x", "y"};
+        ArgChecker arg_checker(sizeof(argv)/sizeof(argv[0]), argv);
+        arg_checker.check_unchanged();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+//____________________________________________________________________________//
+
+// EOF


### PR DESCRIPTION
UTF seems to have some serious issues with its command-line parsing. :-(

This pull request adds a test module for it, and fixes one of the problems - a segfault that occurs if you attempt to pass it an argument with a leading embedded space character or an empty string as the initial but not only argument.

There are other problems with this command-line handling, but I'll add failing tests for some of them as a separate pull request based on this one.

Best regards,
  Jurko Gospodnetić