### PR TITLE
Compile fix for MSVC14

### DIFF
--- a/test/test_tools_test.cpp
+++ b/test/test_tools_test.cpp
@@ -57,7 +57,7 @@ namespace tt=boost::test_tools;
 //____________________________________________________________________________//
 
 // thanks to http://stackoverflow.com/questions/9226400/portable-printing-of-exponent-of-a-double-to-c-iostreams
-#ifdef BOOST_MSVC
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1900)
 struct ScientificNotationExponentOutputNormalizer {
     ScientificNotationExponentOutputNormalizer() : m_old_format(_set_output_format(_TWO_DIGIT_EXPONENT)) {}
 


### PR DESCRIPTION
In Visual C++ 14, _set_output_format and _TWO_DIGIT_EXPONENT have been removed and are not needed anymore:
http://blogs.msdn.com/b/vcblog/archive/2014/06/18/crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1.aspx
