### PR TITLE
Using type_index to avoid all RTTIs. (fixes #9228)

### DIFF
--- a/include/boost/test/execution_monitor.hpp
+++ b/include/boost/test/execution_monitor.hpp
@@ -24,6 +24,7 @@
 #include <boost/type.hpp>
 #include <boost/cstdlib.hpp>
 #include <boost/function/function0.hpp>
+#include <boost/type_index.hpp>
 
 #include <boost/test/detail/suppress_warnings.hpp>
 
@@ -177,17 +178,15 @@ public:
 
         return m_tag == tag ? m_next : this_;
     }
-#ifndef BOOST_NO_RTTI
-    virtual translator_holder_base_ptr erase( translator_holder_base_ptr this_, std::type_info const& ) = 0;
+    virtual translator_holder_base_ptr erase( translator_holder_base_ptr this_, boost::typeindex::type_info const& ) = 0;
     template<typename ExceptionType>
     translator_holder_base_ptr erase( translator_holder_base_ptr this_, boost::type<ExceptionType>* = 0 )
     {
         if( m_next )
             m_next = m_next->erase<ExceptionType>( m_next );
 
-        return erase( this_, typeid(ExceptionType) );
+        return erase( this_, boost::typeindex::type_id<ExceptionType>() );
     }
-#endif
 
 protected:
     // Data members
@@ -420,12 +419,10 @@ public:
             return boost::exit_exception_failure;
         }
     }
-#ifndef BOOST_NO_RTTI
-    virtual translator_holder_base_ptr erase( translator_holder_base_ptr this_, std::type_info const& ti ) 
+    virtual translator_holder_base_ptr erase( translator_holder_base_ptr this_, boost::typeindex::type_info const& ti ) 
     {
-        return ti == typeid(ExceptionType) ? m_next : this_;
+        return ti == boost::typeindex::type_id<ExceptionType>() ? m_next : this_;
     }
-#endif
 
 private:
     // Data members

--- a/include/boost/test/tree/test_case_template.hpp
+++ b/include/boost/test/tree/test_case_template.hpp
@@ -33,12 +33,7 @@
 #include <boost/type.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/function/function0.hpp>
-
-#ifndef BOOST_NO_RTTI
-#include <typeinfo> // for typeid
-#else
-#include <boost/current_function.hpp>
-#endif
+#include <boost/type_index.hpp>
 
 // STL
 #include <string>   // for std::string
@@ -82,11 +77,7 @@ struct generate_test_case_4_type {
         std::string full_name;
         assign_op( full_name, m_test_case_name, 0 );
         full_name += '<';
-#ifndef BOOST_NO_RTTI
-         full_name += typeid(TestType).name();
-#else
-        full_name += BOOST_CURRENT_FUNCTION;
-#endif
+        full_name += boost::typeindex::type_id<TestType>().pretty_name();
         if( boost::is_const<TestType>::value )
             full_name += " const";
         full_name += '>';

--- a/include/boost/test/utils/runtime/interpret_argument_value.hpp
+++ b/include/boost/test/utils/runtime/interpret_argument_value.hpp
@@ -26,6 +26,7 @@
 // Boost
 #include <boost/optional.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/type_index.hpp>
 
 // STL
 // !! could we eliminate these includes?
@@ -45,7 +46,7 @@ template<typename T>
 struct interpret_argument_value_impl {
     static bool _( cstring source, boost::optional<T>& res )
     {
-        BOOST_RT_PARAM_TRACE( "In interpret_argument_value_impl<" << typeid(T).name() << ">" );
+        BOOST_RT_PARAM_TRACE( "In interpret_argument_value_impl<" << boost::typeindex::type_id<T>().pretty_name() << ">" );
 
         res = lexical_cast<T>( source );
 

--- a/test/test_datasets_src/test_datasets.hpp
+++ b/test/test_datasets_src/test_datasets.hpp
@@ -18,6 +18,7 @@
 // Boost
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_index.hpp>
 
 #include <iostream>
 #include <vector>
@@ -155,7 +156,7 @@ struct print_sample {
     template<typename T>
     void    operator()( T const& sample ) const
     {
-        std::cout << "S has type: " << typeid(T).name() << " and value " << sample << std::endl;
+        std::cout << "S has type: " << boost::typeindex::type_id<T>().pretty_name() << " and value " << sample << std::endl;
     }
 };
 


### PR DESCRIPTION
A better solution than #ifndef BOOST_NO_RTTI.