### PR TITLE
Fix feature test of BOOST_NO_CXX11_VARIADIC_MACROS

### DIFF
--- a/include/boost/test/test_tools.hpp
+++ b/include/boost/test/test_tools.hpp
@@ -47,7 +47,7 @@
 #  include <boost/test/tools/detail/tolerance_manip.hpp>
 #endif
 
-#if !BOOST_PP_VARIADICS || ((__cplusplus >= 201103L) && BOOST_NO_CXX11_VARIADIC_MACROS)
+#if !BOOST_PP_VARIADICS || ((__cplusplus >= 201103L) && defined(BOOST_NO_CXX11_VARIADIC_MACROS))
 #define BOOST_TEST_NO_VARIADIC
 #endif
 


### PR DESCRIPTION
Change b41a9354e9127e77d19a1b5c975c33729b033218 introduced regression failures due to preprocessor errors with respect to the && operator, leading to the following error:

../boost/test/test_tools.hpp:50:87: error: operator '&&' has no right operand
 #if !BOOST_PP_VARIADICS || ((__cplusplus >= 201103L) && BOOST_NO_CXX11_VARIADIC_MACROS)