### PR TITLE
Customization point for FP types not convertible from int

### DIFF
--- a/doc/adv_scenarios.qbk
+++ b/doc/adv_scenarios.qbk
@@ -8,7 +8,7 @@
 [/ ##################################################################### ]
 [section:adv_scenarios The __UTF__: Advanced Usage Scenarios]
 
-If you are reading this chapter, this means that wide range of tools and interfaces coverred 
+If you are reading this chapter, this means that the wide range of tools and interfaces covered 
 in the [link boost_test.users_guide User Guide] and not sufficient for the testing scenario
 you have in mind. You are here to bend the __UTF__ to your will and ... we are not going to 
 stop you. Instead we'll try to guide you so that some dark corners do not look scary.  
@@ -16,15 +16,15 @@ stop you. Instead we'll try to guide you so that some dark corners do not look s
 In most cases the __UTF__ is going to be supplied for you either as part of your system libraries
 or set of libraries used by your companies. Yet if you are facing the necessity to build your 
 own static or dynamic library of the __UTF__ or need to customize the build for any reason 
-[link boost_test.adv_scenarios.build_lib Build] section convers all the necessary steps.
+[link boost_test.adv_scenarios.build_lib Build] section covers all the necessary steps.
 
-To streamline the expirience of setting up your test module, the __UTF__ provides some default 
+To streamline the experience of setting up your test module, the __UTF__ provides some default 
 initialization logic for them. Usually the default test module initialization will work just fine,
 but if you want to implement some custom initialization or change how default initialization 
 behaves you need to first look in [*Test module initialization] section. Here you'll learn 
 about various options the __UTF__ provides for you to customize this behaviour.
 
-The part of the framework which loads, initializes and executed yout test module is called the 
+The part of the framework which loads, initializes and executed your test module is called the 
 [*Test Runner]. Each usage variant comes with default test runner. If, instead, you prefer to 
 implement your own entry point into the test module (for example if you need to implement the
 `main` function yourself and not use the one provided by the __UTF__, you need to learn about 
@@ -35,6 +35,10 @@ customization of initialization logic like
 are not sufficient for your purposes.
 
 [/ build and link with boost.test]
+[include adv_scenarios/building_utf.qbk]
+[include adv_scenarios/entry_point_overview.qbk]
+[include adv_scenarios/test_module_init_overview.qbk]
+[include adv_scenarios/test_module_runner_overview.qbk]
 [include adv_scenarios/building_and_linking.qbk]
 [include adv_scenarios/customizing_key_components.qbk]
 

--- a/doc/adv_scenarios/building_and_linking.qbk
+++ b/doc/adv_scenarios/building_and_linking.qbk
@@ -7,62 +7,6 @@
 
 [section:build_lib Building and linking]
 
-[section:build_utf Building the __UTF__]
-In case you would like to use the shared or static variants of the __UTF__, the library needs to be built. 
-Building the __UTF__ is in fact quite easy.
-
-In the sequel, we define
-
-* $`boost_path` refers to the location where the boost archive was deflated
-* $`boost_installation_prefix` refers to the location where you want to install the __UTF__
-
-[/ not true
- [note By default, the static and dynamic variant will be built for your operating system]
-]
-
-More documentation about Boost's build system can be found [@http://www.boost.org/more/getting_started/index.html here]. 
-
-[h3 Windows]
-
-You need to have a compilation toolchain. /Visual Studio Express/ is such one, freely available from the 
-Microsoft website. Once installed, 
-
-[h4 Static variant]
-For building 32bits libraries, open a console window and enter the following commands:
-```
-> cd ``$``boost_path
-> boostrap.bat
-> b2 address-model=32 architecture=x86 --with-test --link=static \
->                     --prefix=``$``boost_installation_prefix install
-```
-
-For building 64bits libraries, the commands become:
-```
-> cd ``$``boost_path
-> boostrap.bat
-> b2 address-model=64 architecture=x86 --with-test --link=static \
->                    --prefix=``$``boost_installation_prefix install
-```
-
-[h4 Shared library variant]
-In order to build the shared library variant, the directive `--link=static` should be replaced by `--link=shared` on the above command lines. 
-For instance, for 64bits builds, the commands become:
-
-```
-> cd ``$``boost_path
-> boostrap.bat
-> b2 address-model=64 architecture=x86 --with-test --link=shared --prefix=``$``boost_installation_prefix install
-```
-
-[h3 Linux/OSX]
-For Unix/Linux/OSX operating system, the build of the __UTF__ is very similar to the one on Windows:
-```
-> cd ``$``boost_path
-> ./boostrap.sh
-> ./b2 --with-test --prefix=``$``boost_installation_prefix install
-```
-
-[endsect] [/buildutf]
 
 [section:build Building a test module with the __UTF__]
 

--- a/doc/adv_scenarios/building_utf.qbk
+++ b/doc/adv_scenarios/building_utf.qbk
@@ -1,0 +1,65 @@
+[/
+ / Copyright (c) 2003-2014 Gennadiy Rozental 
+ / Copyright (c) 2015 Andrzej Krzemienski
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+
+[section:build_utf Building the __UTF__]
+In case you would like to use the [link boost_test.users_guide.usage_variants.shared_lib shared library variant] or the [link boost_test.users_guide.usage_variants.static_lib static library variant] of the __UTF__, the library needs to be built. 
+Building the __UTF__ is in fact quite easy.
+
+In the sequel, we define
+
+* $`boost_path` refers to the location where the boost archive was deflated
+* $`boost_installation_prefix` refers to the location where you want to install the __UTF__
+
+[/ not true
+ [note By default, the static and dynamic variant will be built for your operating system]
+]
+
+More documentation about Boost's build system can be found [@http://www.boost.org/more/getting_started/index.html here]. 
+
+[h3 Windows]
+
+You need to have a compilation toolchain. /Visual Studio Express/ is such one, freely available from the 
+Microsoft website. Once installed, 
+
+[h4 Static variant]
+For building 32bits libraries, open a console window and enter the following commands:
+```
+> cd ``$``boost_path
+> boostrap.bat
+> b2 address-model=32 architecture=x86 --with-test --link=static \
+>                     --prefix=``$``boost_installation_prefix install
+```
+
+For building 64bits libraries, the commands become:
+```
+> cd ``$``boost_path
+> boostrap.bat
+> b2 address-model=64 architecture=x86 --with-test --link=static \
+>                    --prefix=``$``boost_installation_prefix install
+```
+
+[h4 Shared library variant]
+In order to build the shared library variant, the directive `--link=static` should be replaced by `--link=shared` on the above command lines. 
+For instance, for 64bits builds, the commands become:
+
+```
+> cd ``$``boost_path
+> boostrap.bat
+> b2 address-model=64 architecture=x86 --with-test --link=shared --prefix=``$``boost_installation_prefix install
+```
+
+[h3 Linux/OSX]
+For Unix/Linux/OSX operating system, the build of the __UTF__ is very similar to the one on Windows:
+```
+> cd ``$``boost_path
+> ./boostrap.sh
+> ./b2 --with-test --prefix=``$``boost_installation_prefix install
+```
+
+[endsect] [/build_utf]

--- a/doc/adv_scenarios/entry_point_overview.qbk
+++ b/doc/adv_scenarios/entry_point_overview.qbk
@@ -1,0 +1,34 @@
+[/
+ / Copyright (c) 2015 Andrzej Krzemienski
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+[section:entry_point_overview Test module's entry point]
+
+Typically, every C++ program contains exactly one definition of function `main`: the program's /entry point/.
+When using the __UTF__ you do not have to define one. Function `main` will be generated for you by the framework.
+The only thing you are required to do in case your program consists of more than one translation unit (`cpp` file)
+is to indicate to the framework in which of the files it is supposed to generate function `main`.
+You do it by defining macro __BOOST_TEST_MODULE__ before the inclusion of any of the framework files.
+The value of this macro is used as a name of the [link ref_test_module test module] as well as the [link boost_test.users_guide.tests_organization.test_suite.master_test_suite master test suite]. 
+
+The reason for defining function `main` for you is twofold:
+
+# This allows the __UTF__ to perform some custom [link boost_test.adv_scenarios.test_module_init_overview ['test module initialization]].
+# This prevents you defining `main`, and accidentally forgetting to run all the test (in which case running the program would incorrectly indicate a clean run).
+
+By default, the test module's entry point is defined with signature:
+
+```
+int main(int argc, char* argv[]);
+```
+
+It calls [link boost_test.adv_scenarios.test_module_init_overview ['test module initialization]] function, then calls the [link boost_test.adv_scenarios.test_module_runner_overview ['test module runner]] and forwards its return value to environment. For overriding the definition of the default test module's entry point:
+
+* `see here`, for single header usage variant,
+* `see here`, for static library usage variant,
+* `see here`, for shared library usage variant.
+
+[endsect] [/section:entry_point_overview]

--- a/doc/adv_scenarios/test_module_init_overview.qbk
+++ b/doc/adv_scenarios/test_module_init_overview.qbk
@@ -1,0 +1,32 @@
+[/
+ / Copyright (c) 2015 Andrzej Krzemienski
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+[section:test_module_init_overview Test module's initialization]
+
+In order for a unit test module to successfully link and execute, it has to have access to the ['test module's initialization function]. the module's initialization function is called only once during the execution of the program, just before the [link boost_test.adv_scenarios.test_module_runner_overview ['test module runner]] is run. By default, the __UTF__ provides a default definition of initialization function. The only thing you have to do is to instruct the framework in which translation unit (`cpp` file) it needs to provide the definition. You do it by defining macro __BOOST_TEST_MODULE__ in the designated file. The default implementation assigns the name to the [link ref_test_module test module] as well as the [link boost_test.users_guide.tests_organization.test_suite.master_test_suite master test suite]. The name to be assigned is specified by the value of the macro __BOOST_TEST_MODULE__.
+
+There is practically no need to ever alter the default behaviour of the test module's initialization function. The __UTF__ provides superior tools for performing customization tasks:
+
+* for automatic registration of test cases and test suites in the test tree, see section [link boost_test.users_guide.tests_organization Tests organization];
+* in order to assign the custom name to the master test suite define macro __BOOST_TEST_MODULE__ to desired value;
+* in order to access the command-line parameters (except the ones consumed by the __UTF__), use the interface of the [link boost_test.users_guide.tests_organization.test_suite.master_test_suite master test suite];
+* in order to perform a global initialization of the state required by the test cases, [link boost_test.users_guide.tests_organization.fixtures.global global fixtures] offer a superior alternative: you can specify global set-up and tear-down in one place, allow access to the global data from every test case, and guarantee that clean-up and tear-down is repeated each time the tests are re-run during the execution of the program;
+* if the need for custom module initialization is only driven by legacy code (written against old versions of the __UTF__), it is recommended to update your program's code.
+
+The default initialization function provided by the framework is defined with the following signature in the global namespace:
+
+```
+bool init_unit_test();
+```
+
+For overriding the default definition:
+
+* `see here`, for single header usage variant,
+* `see here`, for static library usage variant,
+* `see here`, for shared library usage variant.
+
+[endsect] [/section:test_module_init_overview]

--- a/doc/adv_scenarios/test_module_runner_overview.qbk
+++ b/doc/adv_scenarios/test_module_runner_overview.qbk
@@ -1,0 +1,47 @@
+[/
+ / Copyright (c) 2015 Andrzej Krzemienski
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+[section:test_module_runner_overview Test module runner]
+
+A ['test module runner] is an ['orchestrator] or a ['driver] that, given the test tree, ensures the test tree is initialized, tests are executed and necessary reports generated. It performs the following operations:
+
+* initialize the test module using the supplied [link boost_test.adv_scenarios.test_module_init_overview ['initialization function]];
+* select output media for the test log and the test results report;
+* execute test cases as specified by run-time parameters;
+* produce the test results report; 
+* generate the appropriate return code.
+
+The __UTF__ comes with the default test runner. There is no need to call it explicitly. The default generated test module's [link boost_test.adv_scenarios.entry_point_overview entry point] invokes the default test runner. The default test runner is declared with the following signature:
+
+```
+namespace boost { namespace unit_test {
+
+  typedef bool (*init_unit_test_func)();
+
+  int unit_test_main( init_unit_test_func init_func, int argc, char* argv[] );
+
+} }
+```
+
+The test runner may return one of the following values:
+
+[table
+[[Value][Meaning]]
+[[`boost::exit_success`][
+* No errors occurred during testing, or
+* the success result was forced with command-line argument `--__param_result_code__=no`.]]
+[[`boost::exit_test_failure`][
+* Non-fatal errors detected and no uncaught exceptions were thrown during testing, or
+* the initialization of the __UTF__ failed. ]]
+[[`boost::exit_exception_failure`][
+* Fatal errors were detected, or
+* uncaught exceptions thrown during testing. ]]
+]
+
+An advanced test runner may provide additional features, including interactive GUI interfaces, test coverage and profiling support. 
+
+[endsect] [/section:test_module_runner_overview]

--- a/doc/closing_chapters/glossary.qbk
+++ b/doc/closing_chapters/glossary.qbk
@@ -89,20 +89,7 @@ This is the part of test module that is responsible for cleanup operations.
 Matching setup and cleanup operations are frequently united into a single entity called test fixture.
 
 [#test_runner][h3 Test runner]
-This is an ['executive manager] that runs the show. The test runner's functionality should include
-the following interfaces and operations:
-
-* Entry point to a test module. This is usually either the function `main()` itself or single function that can be
-  invoked from it to start testing.
-* Initialize the __UTF__ based on runtime parameters
-* Select an output media for the test log and the test results report
-* Select test cases to execute based on runtime parameters
-* Execute all or selected test cases
-* Produce the test results report
-* Generate a test module result code.
-
-An advanced test runner may provide additional features, including interactive ['GUI] interfaces,
-test coverage and profiling support.
+This is an ['orchestrator] or a ['driver] that, given the test tree, ensures the test tree is initialized, tests are executed and necessary reports generated. For more information [link boost_test.adv_scenarios.test_module_runner_overview see here].
 
 [#test_log][h3 Test log]
 This is the record of all events that occur during the testing.

--- a/doc/usage_variants.qbk
+++ b/doc/usage_variants.qbk
@@ -41,7 +41,7 @@ boost_test.adv_scenarios.build_lib.usage_variants.single_header_variant section]
 [h3:static_lib Static library usage variant]
 For most users, who has an access to prebuild static library [footnote these files are distributed 
 with the packaging systems on Linux and OSX for instance] of the __UTF__ or can 
-[link boost_test.adv_scenarios.build_lib.build_utf build it] themselves, following usage can be most versatile
+[link boost_test.adv_scenarios.build_utf build it] themselves, following usage can be most versatile
  and simple approach. This usage variant entails two steps. 
 
 # First you need to add following line to all translation units in a test module:


### PR DESCRIPTION
I am not 100% if it does not break anything, so please check if this change is acceptable, and if all tests pass.

The idea behind the change is that the floating point utils work even if the floating-point type is not default constructible, and is not convertible from int. In that case, the user has to specialize function:
```
boost::math::fpc::floating_point_from_int<UDT>(int);
```