### PR TITLE
Add needed MPL header file.

### DIFF
--- a/include/boost/test/tools/floating_point_comparison.hpp
+++ b/include/boost/test/tools/floating_point_comparison.hpp
@@ -20,6 +20,7 @@
 #include <boost/limits.hpp>  // for std::numeric_limits
 #include <boost/static_assert.hpp>
 #include <boost/assert.hpp>
+#include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <boost/type_traits/is_array.hpp>
 #include <boost/utility/enable_if.hpp>


### PR DESCRIPTION
The MPL header file needs to be correctly included. This is necessary for upcoming type_traits version 2, which does not depend on MPL anymore.