### PR TITLE
Doc: simpler introduction

### DIFF
--- a/doc/closing_chapters/faq.qbk
+++ b/doc/closing_chapters/faq.qbk
@@ -75,7 +75,43 @@ Yes. Starting with Boost 1.34.0.
 
 [h3 How to set up a cmake project using __UTF__ (extended)]
 
-Following the [link boost_test.intro.5min_starter 5min starter guide], it is very easy to set up a cmake project using __UTF__.
+Suppose, you are building a test module from one translation unit `test_file.cpp`. First, let's do it using the [link boost_test.usage_variants.single_header single-header usage variant] of the __UTF__.
+
+Let's paste the following content in a `CMakeLists.txt` 
+at the same location than our test file `test_file.cpp`:
+
+[pre
+cmake_minimum_required(VERSION 2.8.7)
+project(my_first_test)
+enable_testing()
+
+# indicates the location of the boost installation tree.
+# hard-coded for our simple example.
+set(BOOST_INCLUDE_DIRS $boost_installation_prefix/include)
+
+# creates the executable
+add_executable(test_executable test_file.cpp)
+# indicates the include paths
+target_include_directories(test_executable PRIVATE ${BOOST_INCLUDE_DIRS})
+
+# declares a test with our executable
+add_test(NAME test1 COMMAND test_executable)
+]
+
+We will now create the build directory for this project (separate directory), 
+configure and build the project, as follow:
+```
+> cd ``$``test_path
+> mkdir build     /*< we create a directory dedicated to the build, to avoid 
+                      any pollution of the sources with the temporary
+                      build files >*/
+> cd build
+> cmake  ..       /*< configuration of the project >*/
+> cmake --build . /*< this command builds the project, cmake drives a native 
+                      tool that is configured on the previous command line >*/
+> ctest           /*< runs the tests declared in the project and prints a report >*/
+```
+
 In the case you are using the [link boost_test.usage_variants.shared_lib shared libraries] variant of __UTF__, 
 some modifications should be done in your CMakeLists.txt. 
 

--- a/doc/examples/decorator_01.output
+++ b/doc/examples/decorator_01.output
@@ -1,11 +1,11 @@
 //[example_output
-> decorator_01 --run_test=@trivial
+> decorator_01 --run_test=\@trivial
 Running 2 test cases...
 
 *** No errors detected
 
 
-> decorator_01 --run_test=@cmp
+> decorator_01 --run_test=\@cmp
 Running 1 test case...
 
 *** No errors detected

--- a/doc/introduction/5min_primer.qbk
+++ b/doc/introduction/5min_primer.qbk
@@ -15,20 +15,17 @@ Let's start by creating the minimal skeleton for our [link ref_test_module test 
 looks like this:
 
 ``
-#define __BOOST_TEST_MODULE__ My Test
-#include <boost/test/included/unit_test.hpp>
+#define __BOOST_TEST_MODULE__ My Test /*< Macro __BOOST_TEST_MODULE__ defines the name of our program, which will be used in messages. >*/
+#include <boost/test/included/unit_test.hpp> /*< This includes all the __UTF__ in a "single header mode"; it even defines function `main`, which will call the subsequently defined test cases. >*/
 
-__BOOST_AUTO_TEST_CASE__(first_test)
+__BOOST_AUTO_TEST_CASE__(first_test) /*< Macro __BOOST_AUTO_TEST_CASE__ declares a ['test case] named `first_test`, which in turn will run the content of `first_test` inside the 
+controlled testing environment.>*/
 {
-  __BOOST_TEST__(true);
-  
   int i = 1;
-  __BOOST_TEST__(i == 2);
+  __BOOST_TEST__(i); /*< This test checks if `i` is non-zero. >*/
+  __BOOST_TEST__(i == 2); /*< This test checks if `i` has value `2` (something more than just evaluating the equality operator). >*/
 }
 `` 
-
-The command/macro __BOOST_AUTO_TEST_CASE__ declares a test named `first_test`, which in turn will run the content of `first_test` inside the 
-controlled testing environment. This test checks that `true` is `true` and that `i` equals `2` and should succeed first test and fail second. 
 
 Before continuing in adding value to the test module itself, let's now build the test module contained in [*an unique]
 [footnote with more than one file, one line should be changed] file. For building this specific test module, we just have to
@@ -53,9 +50,9 @@ If you haven't seen any error message, you can run the test:
 and it shoud show something like:
 [pre
 Running 1 test case...
-test_file.cpp(9): error: in "first_test": check i == 2 has failed [1 != 2]
+test_file.cpp(8): error: in "first_test": check i == 2 has failed [1 != 2]
 
-*** 1 failure detected in test module "My Test"
+*** 1 failure is detected in the test module "My Test"
 ]
 
 The command line is similar for `clang`. 

--- a/doc/introduction/how_to_read.qbk
+++ b/doc/introduction/how_to_read.qbk
@@ -21,8 +21,7 @@ Well ... This is a User's Guide after all. Let's go by what *you*, as a user, ne
 successfully use the __UTF__. Thus we follow the order of decisions you have to make and order
 of complexity of the problems you might encounter. If you find yourself faced with some unclear term feel 
 free to jump directly to the [link boost_test.section_glossary glossary] section, where short definitions 
-for all used terms were collected. And if you want to jump right into coding the 
-[link boost_test.intro.5min_starter "the 5min starter guide"] would be a better place to start.
+for all used terms were collected.
 
 The __UTF__ has several usage variants. And the first decision you have to make is which one to use. These
 variants are covered in section dedicated to [link boost_test.usage_variants Usage variants]. 

--- a/doc/introduction/introduction.qbk
+++ b/doc/introduction/introduction.qbk
@@ -32,43 +32,37 @@ programs, organizing tests into simple test cases and test suites, and controlli
 Some of Boost.Test's interfaces are also useful in production (non-test) environments. 
 
 [/ ##################################################################### ]
-[h3 Rationale]
 
-Unit testing tasks arise during many different stages of software development: from initial project 
-implementation to its maintenance and later revisions. These tasks differ in their complexity and purpose 
-and accordingly are approached differently by different developers. The wide spectrum of tasks in a problem
-domain cause many requirements (sometimes conflicting) to be placed on a unit testing framework. These
-include:
+[h3 Starter example]
 
-* Writing a unit test module should be simple and obvious for new users.
-* The framework should allow advanced users to perform non-trivial tests.
-* Test module should be able to have many small test cases and developer should be able to group them into 
-  test suites.
-* At the beginning of the development users want to see verbose and descriptive error message, whereas 
-  during the regression testing they just want to know if any tests failed.
-* For a small test modules run time should prevail over compilation time: user don't want to wait a minute
-  to compile a test that takes a second to run.
-* For long and complex tests users want to be able to see the test progress.
-* Simplest tests shouldn't require an external library.
-* For long term usage users of a unit test framework should be able to build it as a standalone library.
+This is how a minimal single-file test program looks like:
 
-The __UTF__ design is based on above rationale and provides versatile facilities to:
+``
+#define __BOOST_TEST_MODULE__ My Test /*< Macro __BOOST_TEST_MODULE__ defines the name of our program, which will be used in messages. >*/
+#include <boost/test/included/unit_test.hpp> /*< This includes all the __UTF__ in a "single header mode"; it even defines function `main`, which will call the subsequently defined test cases. >*/
 
-* Simplify writing test cases by using various [link boost_test.testing_tools Testing tools].
-* Organize test cases into a [link boost_test.tests_organization test tree].
-* Relieve you from messy error detection, reporting duties and framework runtime parameters processing.
+__BOOST_AUTO_TEST_CASE__(first_test) /*< Macro __BOOST_AUTO_TEST_CASE__ declares a ['test case] named `first_test`, which in turn will run the content of `first_test` inside the 
+controlled testing environment.>*/
+{
+  int i = 1;
+  __BOOST_TEST__(i); /*< This test checks if `i` is non-zero. >*/
+  __BOOST_TEST__(i == 2); /*< This test checks if `i` has value `2` (something more than just evaluating the equality operator). >*/
+}
+`` 
 
-The __UTF__ is intended to be used both for a simple and non trivial testing. 
+When run, it produces the following output:
 
+[pre
+Running 1 test case...
+test_file.cpp(8): error: in "first_test": check i == 2 has failed [1 != 2]
+
+*** 1 failure is detected in the test module "My Test"
+]
 
 [/ ##################################################################### ]
 
-[include how_to_read.qbk]
-[include 5min_primer.qbk]
+[include overview.qbk]
 
-
-[include tutorials/tutorial_hello_world.qbk]
-[include tutorials/tutorial_new_year_resolution.qbk]
 
 [endsect]
 

--- a/doc/introduction/overview.qbk
+++ b/doc/introduction/overview.qbk
@@ -1,0 +1,62 @@
+[/
+ / Copyright (c) 2003-2014 Gennadiy Rozental 
+ / Copyright (c) 2013-2014 Raffi Enficiaud
+ / Copyright (c) 2015 Andrzej Krzemienski
+ /
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+ 
+[section:overview Framework overview]
+
+[h3:design_criteria Design criteria]
+
+Unit testing tasks arise during many different stages of software development: from initial project 
+implementation to its maintenance and later revisions. These tasks differ in their complexity and purpose 
+and accordingly are approached differently by different developers. The wide spectrum of tasks in a problem
+domain cause many requirements (sometimes conflicting) to be placed on a unit testing framework. These
+include:
+
+* Writing a [link ref_test_module unit test module] should be simple and obvious for new users.
+* The framework should allow advanced users to perform non-trivial tests.
+* Test module should be able to have many small test cases and developer should be able to group them into 
+  test suites.
+* At the beginning of the development users want to see verbose and descriptive error messages.
+* During the regression testing users just want to know if any tests failed.
+* For small test modules, their execution time should prevail over compilation time: user don't want to wait a minute
+  to compile a test that takes a second to run.
+* For long and complex tests users want to be able to see the testing progress.
+* Simplest tests shouldn't require an external library.
+* For long term usage users of the __UTF__ should be able to build it as a standalone library.
+
+The __UTF__ addresses the above expectations, and provides versatile facilities to:
+
+* Specify what behaviour you expect of the tested pieces (see section [link boost_test.testing_tools Testing tools])
+* Organize the [link test_case test cases] into a [link test_tree test tree] (see section [link boost_test.tests_organization Declaring and organizing tests]).
+* Detect different kinds of errors, failures, time-outs and report them in a uniform customizable way (see section [link boost_test.test_output Controlling output]). 
+
+[h3:why_framework Why do you need a framework?]
+
+While you can write a testing program yourself from scratch, the framework offers the following benefits:
+
+* You get an error report in a text format. Error reports are uniform and you can easily machine-analyse them.
+* Error reporting is separated from the testing code. You can easily change the error report format without affecting the testing code.
+* The framework automatically detects exceptions thrown by the tested components and time-outs, and reports them along other errors.
+* You can easily filter the test cases, and call only the desired ones. This does not require changing the testing code. 
+ 
+[h3:working_with_utf Working with the __UTF__]
+
+In this documentation we refer to a 'testing` program as [link ref_test_module ['test module]]. Typically, when writing a test module using the __UTF__ you will have to go through the following tasks:
+
+* Decide how you want to incorporate the __UTF__: `#include` it as a header-only library, or link with it as a static library,
+  or use it as a shared (or dynamically loaded) library. For details on this topic see section [link boost_test.usage_variants Usage variants].
+* Add a [link test_case test case] into a [link test_tree test tree]. For details, see section [link boost_test.tests_organization.test_cases Test cases].
+* Perform correctness checks of the tested unit. For details, see section [link boost_test.testing_tools Writing unit tests].
+* Perform the automated initialization of tested units before each test. For details, see section [link boost_test.tests_organization.fixtures Fixtures].
+* Customize the way test failures are reported. For details, see section [link boost_test.test_output Controlling output].
+* Control the run-time behaviour of the built test module (e.g., run only selected tests, change the output format). This is covered in section [link boost_test.runtime_config Runtime configuration].  
+
+[endsect][/ overview]
+
+[/ EOF]

--- a/doc/snippet/snippet12.cpp
+++ b/doc/snippet/snippet12.cpp
@@ -10,29 +10,28 @@
 #define __BOOST_TEST_MODULE__ MyTest
 #include <boost/test/unit_test.hpp>
 
-int add( int i, int j ) { return i+j; }
+int add( int i, int j ) { return i + j; }
 
-__BOOST_AUTO_TEST_CASE__( my_test )
+__BOOST_AUTO_TEST_CASE__(my_test)
 {
-  // seven ways to detect and report the same error:
+  // six ways to detect and report the same error:
 
   // continues on error
-  __BOOST_CHECK__( add( 2,2 ) == 4 );        /*<
-                                          This approach uses the __BOOST_CHECK__ tool, which displays an error message (by default on `std::cout`) that includes
-                                          the expression that failed, the source file name, and the source file line number. It also increments the error
-                                          count. At program termination, the error count will be displayed automatically by the Unit Test Framework.>*/
+  __BOOST_TEST__( add(2, 2) == 4 );          /*<
+                                          This approach uses tool __BOOST_TEST__, which displays an error message (by default on `std::cout`) that includes
+                                          the expression that failed, as well as the values on the two side of the equation, the source file name,
+                                          and the source file line number. It also increments the error count. At program termination,
+                                          the error count will be displayed automatically by the __UTF__.>*/
   
   // throws on error
-  __BOOST_REQUIRE__( add( 2,2 ) == 4 );      /*<
-                                          This approach uses the __BOOST_REQUIRE__ tool, is similar to approach #1, except that after displaying the error,
-                                          an exception is thrown, to be caught by the Unit Test Framework. This approach is suitable when writing an
-                                          explicit test program, and the error would be so severe as to make further testing impractical. __BOOST_REQUIRE__
-                                          differs from the C++ Standard Library's assert() macro in that it is always generated, and channels error
-                                          detection into the uniform Unit Test Framework reporting procedure.
+  __BOOST_TEST_REQUIRE__( add(2, 2) == 4 );  /*<
+                                          This approach uses tool __BOOST_TEST_REQUIRE__, is similar to approach #1, except that after displaying the error,
+                                          an exception is thrown, to be caught by the __UTF__. This approach is suitable when writing an
+                                          explicit test program, and the error would be so severe as to make further testing impractical.
                                           >*/
   
   //continues on error
-  if( add( 2,2 ) != 4 )
+  if (add(2, 2) != 4)
     __BOOST_ERROR__( "Ouch..." );            /*< 
                                           This approach is similar to approach #1, except that the error detection and error reporting are coded separately.
                                           This is most useful when the specific condition being tested requires several independent statements and/or is
@@ -40,33 +39,26 @@ __BOOST_AUTO_TEST_CASE__( my_test )
                                           >*/
   
   // throws on error
-  if( add( 2,2 ) != 4 )
-    __BOOST_FAIL__( "Ouch..." );            /*<
+  if (add(2, 2) != 4)
+    __BOOST_FAIL__( "Ouch..." );             /*<
                                          This approach is similar to approach #2, except that the error detection and error reporting are coded separately.
                                          This is most useful when the specific condition being tested requires several independent statements and/or is
                                          not indicative of the reason for failure.
                                          >*/
   
   // throws on error
-  if( add( 2,2 ) != 4 )
-    throw "Ouch...";                    /*<
-                                         This approach throws an exception, which will be caught and reported by the Unit Test Framework. The error
+  if (add(2, 2) != 4)
+    throw "Ouch...";                     /*<
+                                         This approach throws an exception, which will be caught and reported by the __UTF__. The error
                                          message displayed when the exception is caught will be most meaningful if the exception is derived from
                                          `std::exception`, or is a `char*` or `std::string`.
                                          >*/
   
   // continues on error
-  __BOOST_CHECK_MESSAGE__(add( 2,2 ) == 4,
-                          "add(..) result: " << add( 2,2 ) ); /*<
-                                                           This approach uses the __BOOST_CHECK_MESSAGE__ tool, is similar to approach #1, 
-                                                           except that similar to the approach #3
-                                                           displays an alternative error message specified as a second argument.
+  __BOOST_TEST__( add(2, 2) == 4,            /*<
+                                                           This approach uses tool __BOOST_TEST__ with additional message argument, is similar to approach #1, 
+                                                           except that similar to the approach #3 displays an alternative error message specified as a second argument.
                                                            >*/
-  
-  // continues on error
-  __BOOST_CHECK_EQUAL__( add( 2,2 ), 4 );   /*<
-                                         This approach uses the __BOOST_CHECK_EQUAL__ tool and functionally is similar to approach #1. This approach is most
-                                         attractive for checking equality of two variables, since in case of error it shows mismatched values.
-                                         >*/
+              "2 plus 2 is not 4 but " << add(2, 2));
 }
 //]

--- a/doc/test.qbk
+++ b/doc/test.qbk
@@ -59,6 +59,7 @@
 
 [/ Assertions ]
 [def __BOOST_TEST__                       [link boost_test.utf_reference.testing_tool_ref.assertion_boost_test_super_macro `BOOST_TEST`]]
+[def __BOOST_TEST_REQUIRE__               `BOOST_TEST_REQUIRE`]
 
 [def __BOOST_LEVEL__                      [link boost_test.utf_reference.testing_tool_ref.assertion_boost_level `BOOST_<level>`]]
 [def __BOOST_CHECK__                      [link boost_test.utf_reference.testing_tool_ref.assertion_boost_level `BOOST_CHECK`]]

--- a/doc/testing_tools/testing_tools_summary.qbk
+++ b/doc/testing_tools/testing_tools_summary.qbk
@@ -6,6 +6,7 @@
  /]
 
 [section:summary Summary of the API for writing tests]
+
 [table
   [
     [Assertions]

--- a/doc/tutorial_new_year_resolution.qbk
+++ b/doc/tutorial_new_year_resolution.qbk
@@ -5,7 +5,7 @@
  / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
  /]
 
-[section:bt_and_tdd Test driven development with boost.test]
+[section:bt_and_tdd Test driven development with Boost.Test]
 
 Today is a momentous day - first day of new year. Today I am going to start a new life. I am going to stop eating a
 greasy food, start attending a fitness club and ... today I am going to test programs I am writing. I can start
@@ -20,7 +20,7 @@ read-only access to the preallocated character buffer. I will probably want `con
 interface similar to the class std::string. What will I do first? In my new life I will start with writing a test 
 module for future class `const_string`. It will look like this:
 
-[import ../../snippet/snippet13.cpp]
+[import snippet/snippet13.cpp]
 [snippet13]
  
 Now I can compile it and link with the unit test framework. Done! I have a working test program. It is empty, so
@@ -32,13 +32,13 @@ when I run the program it produces following output:
 Well, now it could be a good time to start a work on `const_string`. First thing I imagine would be good
 to have is a constructors and trivial access methods. So my class initial version looks like this:
 
-[import ../../snippet/snippet14.cpp]
+[import snippet/snippet14.cpp]
 [snippet14]
  
 Now I am able to write a first test case - constructors testing - and add it to a test suite. My test program became
 to look like this:
 
-[import ../../snippet/snippet15.cpp]
+[import snippet/snippet15.cpp]
 [snippet15]
  
 The constructors_test test case is intended to check a simple feature of the class `const_string`: an
@@ -58,12 +58,12 @@ and the unit test framework gives me the following report:
  
 Encouraged I am moving on and adding more access methods:
  
-[import ../../snippet/snippet16.cpp]
+[import snippet/snippet16.cpp]
 [snippet16]
 
 I added the new feature - I need a new test case to check it. As a result my test suite became to look like this:
  
-[import ../../snippet/snippet17.cpp]
+[import snippet/snippet17.cpp]
 [snippet17]
 
 
@@ -75,11 +75,11 @@ intended to do: check that the validation is working. A testing of a validation 
 important part of a unit testing and should not be left for a production stage. The data_access_test test case 
 passed and I am ready for the next step.
 
-[import ../../snippet/const_string.hpp]
-[import ../../snippet/const_string_test.cpp]
+[import snippet/const_string.hpp]
+[import snippet/const_string_test.cpp]
 
-Continuing my effort I am able to complete class `const_string` (see [@../../snippet/const_string.hpp Listing 1 =const_string.hpp=]) and testing module for it (see 
-[@../../snippet/const_string_test.cpp Listing 2 =const_string_test.cpp=]) that is checking all features that are presented 
+Continuing my effort I am able to complete class `const_string` (see [@snippet/const_string.hpp Listing 1 =const_string.hpp=]) and testing module for it (see 
+[@snippet/const_string_test.cpp Listing 2 =const_string_test.cpp=]) that is checking all features that are presented 
 in the class `const_string` specification.
  
 

--- a/doc/usage_recommandations.qbk
+++ b/doc/usage_recommandations.qbk
@@ -56,12 +56,6 @@ of unit testing by automating some of the work, in addition every argument type 
 unit test monitor. As a result if one of types produce exception or non-fatal error you may still continue and 
 get results from testing with other types.
 
-[h4 Prefer __BOOST_CHECK_EQUAL__ to __BOOST_CHECK__]
-Even though __BOOST_CHECK__ tool is most generic and allows validating any `bool` convertible expression, I would 
-recommend using, if possible, more specific tools dedicated to the task. For example if you need you validate 
-some variable vs. some expected value use __BOOST_CHECK_EQUAL__ instead. The main advantage is that in case of 
-failure you will see the mismatched value - the information most useful for error identification. The same 
-applies to other tools supplied by the framework.
 
 [h3 IDE usage recommendations]
 
@@ -143,6 +137,8 @@ later on. Moreover you can  make Boost.Test to produce them in XML format using
 --__param_output_format__=XML
 ``
 and use some automated tool that will format this information as you like.
+
+[include tutorial_new_year_resolution.qbk]
 
 [endsect] [/ recommandations]
 


### PR DESCRIPTION
THe Introduction is now shorter. I removed one tutorial (it is in a non-included qbk file), and moved another one into Practical Usage Recommendations.