### PR TITLE
FPT() --> FPT(0)bb

### DIFF
--- a/doc/examples/decorator_01.output
+++ b/doc/examples/decorator_01.output
@@ -1,11 +1,11 @@
 //[example_output
-> decorator_01 --run_test=\@trivial
+> decorator_01 --run_test=@trivial
 Running 2 test cases...
 
 *** No errors detected
 
 
-> decorator_01 --run_test=\@cmp
+> decorator_01 --run_test=@cmp
 Running 1 test case...
 
 *** No errors detected

--- a/include/boost/test/tools/floating_point_comparison.hpp
+++ b/include/boost/test/tools/floating_point_comparison.hpp
@@ -206,7 +206,7 @@ public:
     explicit    close_at_tolerance( ToleranceType tolerance, fpc::strength fpc_strength = FPC_STRONG ) 
     : m_fraction_tolerance( fpc_detail::fraction_tolerance<FPT>( tolerance ) )
     , m_strength( fpc_strength )
-    , m_tested_rel_diff()
+    , m_tested_rel_diff( 0 )
     {
         BOOST_ASSERT_MSG( m_fraction_tolerance >= FPT(0), "tolerance must not be negative!" ); // no reason for tolerance to be negative
     }

--- a/include/boost/test/tools/fpc_op.hpp
+++ b/include/boost/test/tools/fpc_op.hpp
@@ -134,16 +134,16 @@ public:                                                                 \
     static assertion_result                                             \
     eval( Lhs const& lhs, Rhs const& rhs)                               \
     {                                                                   \
-        if( lhs == Lhs() )                                              \
+        if( lhs == Lhs(0) )                                             \
             return compare_fpv_near_zero<Rhs>(rhs, (OP*)0);             \
                                                                         \
-        if( rhs == Rhs() )                                              \
+        if( rhs == Rhs(0) )                                             \
             return compare_fpv_near_zero<Lhs>(lhs, (OP*)0);             \
                                                                         \
         bool direct_res = eval_direct( lhs, rhs );                      \
                                                                         \
         if((direct_res && fpctraits<OP>::cmp_direct)                    \
-            || fpc_tolerance<FPT>() == FPT())                           \
+            || fpc_tolerance<FPT>() == FPT(0))                          \
             return direct_res;                                          \
                                                                         \
         return compare_fpv<FPT>(lhs, rhs, (OP*)0);                      \

--- a/include/boost/test/tools/fpc_tolerance.hpp
+++ b/include/boost/test/tools/fpc_tolerance.hpp
@@ -36,7 +36,7 @@ template<typename FPT>
 inline FPT&
 fpc_tolerance()
 {
-    static FPT s_value = FPT();
+    static FPT s_value = 0;
     return s_value;
 }
 


### PR DESCRIPTION
Changed the occurences of FPT() to FPT(0). Since we expect a construction from int anyway,
and since the previous implementation assumed that the default constructor initializes to
numeric vaue zero, the change appears uncontroversial. What we gain, is that the default
ctor is no longer required. The FP algos work for non-default-constructible types.