### PR TITLE
v * FTP(0.01)  -->  v / 100

### DIFF
--- a/include/boost/test/tools/detail/tolerance_manip.hpp
+++ b/include/boost/test/tools/detail/tolerance_manip.hpp
@@ -52,7 +52,7 @@ operator%( FPT v, tolerance_manip_delay const& )
     BOOST_STATIC_ASSERT_MSG( (fpc::tolerance_based<FPT>::value), 
                              "tolerance only for floating points" );
 
-    return tolerance_manip<FPT>( FPT(v * FPT(0.01)) ); 
+    return tolerance_manip<FPT>( FPT(v / 100) );
 }
 
 //____________________________________________________________________________//
@@ -108,7 +108,7 @@ tolerance( fpc::percent_tolerance_t<FPT> v )
     BOOST_STATIC_ASSERT_MSG( (fpc::tolerance_based<FPT>::value), 
                              "tolerance only for floating points" );
 
-    return tt_detail::tolerance_manip<FPT>( static_cast<FPT>(v.m_value * 0.01) );
+    return tt_detail::tolerance_manip<FPT>( static_cast<FPT>(v.m_value / 100) );
 }
 
 //____________________________________________________________________________//


### PR DESCRIPTION
Rationale:
Because we are not using the literal of type double, we avoid the bug where `FTP(0.01)` is evaluated as `FTP(int(0.01))` for FPT types that do not offer a conversion from `double`.
I do not use an explicit cast `v / FPT(100)` in order to allow the compiler to see that we are dividing by the integer, and engage optimizations for that case, if any.
By `v / 100` I require that conversion from int to FPT is implicit, and thereby avoid executing explicit constructors, which may have non-conversion semantics.
To the best of my knowledge, `v / 100` is not less accurate than `v * 0.01`. It may be slower, but given that this is evaluated in BOOST_TEST, which does lots of ops on IO streams, this should be negligible; plus, we are affecting only a percentage tolerance manipulator -- not the floating-point comparison itself.