### PR TITLE
Don't use std::numeric_limits when is_specialized is false

### DIFF
--- a/include/boost/test/tools/floating_point_comparison.hpp
+++ b/include/boost/test/tools/floating_point_comparison.hpp
@@ -23,6 +23,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <boost/type_traits/is_array.hpp>
+#include <boost/type_traits/conditional.hpp>
 #include <boost/utility/enable_if.hpp>
 
 // STL
@@ -127,20 +128,37 @@ fpt_abs( FPT fpv )
 //____________________________________________________________________________//
 
 template<typename FPT>
-struct fpt_limits {
-    static FPT    min_value()
-    {
-        return std::numeric_limits<FPT>::is_specialized
-                    ? (std::numeric_limits<FPT>::min)()
-                    : static_cast<FPT>(0);
-    }
-    static FPT    max_value()
-    {
-        return std::numeric_limits<FPT>::is_specialized
-                    ? (std::numeric_limits<FPT>::max)()
-                    : static_cast<FPT>(1000000); // for our purposes it doesn't really matter what value is returned here
-    }
+struct fpt_limits_when_std_specialized
+{
+  static FPT    min_value()
+  {
+    return (std::numeric_limits<FPT>::min)();
+  }
+  static FPT    max_value()
+  {
+    return (std::numeric_limits<FPT>::max)();
+  }
 };
+
+template<typename FPT>
+struct fpt_limits_when_std_not_specialized
+{
+  static FPT    min_value()
+  {
+    return static_cast<FPT>(0);
+  }
+  static FPT    max_value()
+  {
+    return static_cast<FPT>(1000000); // for our purposes it doesn't really matter what value is returned here
+  }
+};
+
+template<typename FPT>
+struct fpt_limits : boost::conditional<std::numeric_limits<FPT>::is_specialized,
+                                       fpt_limits_when_std_specialized<FPT>,
+                                       fpt_limits_when_std_not_specialized<FPT>
+                                      >::type
+{};
 
 //____________________________________________________________________________//
 

--- a/include/boost/test/tools/fpc_op.hpp
+++ b/include/boost/test/tools/fpc_op.hpp
@@ -19,7 +19,7 @@
 #include <boost/test/tools/fpc_tolerance.hpp>
 
 // Boost
-#include <boost/numeric/conversion/conversion_traits.hpp> // for numeric::conversion_traits
+#include <boost/type_traits/common_type.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #include <boost/test/detail/suppress_warnings.hpp>
@@ -120,7 +120,7 @@ struct name<Lhs,Rhs,typename boost::enable_if_c<                        \
     (fpc::tolerance_based<Lhs>::value &&                                \
      fpc::tolerance_based<Rhs>::value)>::type> {                        \
 public:                                                                 \
-    typedef typename numeric::conversion_traits<Lhs,Rhs>::supertype FPT;\
+    typedef typename common_type<Lhs,Rhs>::type FPT;                    \
     typedef name<Lhs,Rhs> OP;                                           \
                                                                         \
     typedef assertion_result result_type;                               \


### PR DESCRIPTION
Prior to this change, in floating-point computations, in the case
where we work for types where std::numeric_limits are not specialized,
funcitons min() and max() from std::numeric_limits<FPT> are nonetheless
instantiated and return FPT(0). While the result is never used in run-time,
this may still trigger a compile-time failure.

After this change, the paths for the cases where std::numeric_limits are not
specialized are handled by separate specializations rather than run-time if
statements.