### PR TITLE
Changed v == T(0)  to  v == 0

### DIFF
--- a/include/boost/test/tools/fpc_op.hpp
+++ b/include/boost/test/tools/fpc_op.hpp
@@ -134,10 +134,10 @@ public:                                                                 \
     static assertion_result                                             \
     eval( Lhs const& lhs, Rhs const& rhs)                               \
     {                                                                   \
-        if( lhs == Lhs(0) )                                             \
+        if( lhs == 0 )                                                  \
             return compare_fpv_near_zero<Rhs>(rhs, (OP*)0);             \
                                                                         \
-        if( rhs == Rhs(0) )                                             \
+        if( rhs == 0 )                                                  \
             return compare_fpv_near_zero<Lhs>(lhs, (OP*)0);             \
                                                                         \
         bool direct_res = eval_direct( lhs, rhs );                      \


### PR DESCRIPTION
With this change we get a *desired* compile time failure when we are passed type `T` that is not implicitly convertible from `int` but is explicitly convertible. Now, we make an implicit conversion from `int` a requirement and refuse to compile otherwise.

This addresses an issue where the user gives us a type `T` with non-intuitive construction from `int`.