### PR TITLE
Added 'BOOST_TEST_DISABLE_ALT_STACK' flag to use with ESXi build.

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -155,6 +155,8 @@ namespace { void _set_se_translator( void* ) {} }
 #    include <android/api-level.h>
 #  endif
 
+// BOOST_TEST_DISABLE_ALT_STACK is available in case you're crosscompiling a
+// target like ESXi which has no proper flag and doesn't support the alt stack.
 #  if !defined(__CYGWIN__) && !defined(__QNXNTO__) && !defined(__bgq__) && \
    (!defined(__ANDROID__) || __ANDROID_API__ >= 8) && \
    !defined(BOOST_TEST_DISABLE_ALT_STACK)

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -156,7 +156,8 @@ namespace { void _set_se_translator( void* ) {} }
 #  endif
 
 #  if !defined(__CYGWIN__) && !defined(__QNXNTO__) && !defined(__bgq__) && \
-   (!defined(__ANDROID__) || __ANDROID_API__ >= 8)
+   (!defined(__ANDROID__) || __ANDROID_API__ >= 8) && \
+   !defined(BOOST_TEST_DISABLE_ALT_STACK)
 #    define BOOST_TEST_USE_ALT_STACK
 #  endif
 


### PR DESCRIPTION
I needed this flag to target a binary for ESXi. It is a stripped down version of Linux that doesn't support all of the glibc functions, and doesn't provide a compiler. So you need to build your application on a normal machine while taking care not to use unsupported functions. Because it isn't actually built with an ESXi compiler there are no default preprocessor directives to tap into, I wasn't sure of another way to implement this.