### PR TITLE
Fix broken support for building with -fno-exceptions on GCC.

### DIFF
--- a/include/boost/test/detail/throw_exception.hpp
+++ b/include/boost/test/detail/throw_exception.hpp
@@ -29,7 +29,7 @@ namespace boost {
 namespace unit_test {
 namespace ut_detail {
 
-#ifdef BOOST_NO_EXCEPTION
+#ifdef BOOST_NO_EXCEPTIONS
 
 template<typename E>
 inline int

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -243,9 +243,9 @@ report_error( execution_exception::error_code ec, boost::exception const* be, ch
 
     va_end( *args );
 
-    throw execution_exception( ec, buf, execution_exception::location( extract<throw_file>( be ),
+    BOOST_TEST_IMPL_THROW(execution_exception( ec, buf, execution_exception::location( extract<throw_file>( be ),
                                                                        (size_t)extract<throw_line>( be ),
-                                                                       extract<throw_function>( be ) ) );
+                                                                       extract<throw_function>( be ) ) ));
 }
 
 //____________________________________________________________________________//
@@ -1207,7 +1207,7 @@ execution_monitor::execute( boost::function<int ()> const& F )
         return catch_signals( F );
     }
 
-#ifndef BOOST_NO_EXCEPTION
+#ifndef BOOST_NO_EXCEPTIONS
 
     //  Catch-clause reference arguments are a bit different from function
     //  arguments (ISO 15.3 paragraphs 18 & 19).  Apparently const isn't


### PR DESCRIPTION
Boost.Test used to support building with -fno-exceptions on GCC, this patch reinstates that support.