### PR TITLE
Fix compilation with BOOST_NO_EXCEPTIONS

### DIFF
--- a/include/boost/test/detail/throw_exception.hpp
+++ b/include/boost/test/detail/throw_exception.hpp
@@ -32,7 +32,7 @@ namespace ut_detail {
 #ifdef BOOST_NO_EXCEPTIONS
 
 template<typename E>
-inline
+inline void
 BOOST_NORETURN throw_exception(E const& e) { abort(); }
 
 #define BOOST_TEST_IMPL_TRY


### PR DESCRIPTION
The return type of throw_exception was missing.