### PR TITLE
Do not qualify <fenv.h> names that might be macros.

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1380,8 +1380,8 @@ enable( unsigned mask )
 
     return ~old_cw & BOOST_FPE_ALL;
 #elif defined(__GLIBC__) && defined(__USE_GNU) && !defined(BOOST_CLANG) && !defined(BOOST_NO_FENV_H)
-    ::feclearexcept(BOOST_FPE_ALL);
-    int res = ::feenableexcept( mask );
+    feclearexcept(BOOST_FPE_ALL);
+    int res = feenableexcept( mask );
     return res == -1 ? (unsigned)BOOST_FPE_INV : (unsigned)res;
 #else
     /* Not Implemented  */
@@ -1417,8 +1417,8 @@ disable( unsigned mask )
 
     return ~old_cw & BOOST_FPE_ALL;
 #elif defined(__GLIBC__) && defined(__USE_GNU) && !defined(BOOST_CLANG) && !defined(BOOST_NO_FENV_H)
-    ::feclearexcept(BOOST_FPE_ALL);
-    int res = ::fedisableexcept( mask );
+    feclearexcept(BOOST_FPE_ALL);
+    int res = fedisableexcept( mask );
     return res == -1 ? (unsigned)BOOST_FPE_INV : (unsigned)res;
 #else
     /* Not Implemented */


### PR DESCRIPTION
This fixes a build failure for GNU/Linux on powerpc, as described at https://bugzilla.redhat.com/show_bug.cgi?id=1262444

This is the same problem described at https://svn.boost.org/trac/boost/ticket/6767