### PR TITLE
Fix for clang on windows

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1137,6 +1137,7 @@ execution_monitor::catch_signals( boost::function<int ()> const& F )
     detail::system_signal_exception SSE( this );
 
     int ret_val = 0;
+    bool l_catch_system_errors = p_catch_system_errors;
 
     __try {
         __try {
@@ -1147,7 +1148,7 @@ execution_monitor::catch_signals( boost::function<int ()> const& F )
         }
     }
     __finally {
-        if( p_catch_system_errors ) {
+        if( l_catch_system_errors ) {
             BOOST_TEST_CRT_SET_HOOK( old_crt_hook );
 
            _set_invalid_parameter_handler( old_iph );


### PR DESCRIPTION
When I try to build with clang on windows (4.2.1 Compatible Clang 3.9.0 (trunk), on top of VC14) I get an error complaining that accessing "this" within an __except block is unimplemented.  This patch just stores the value in a local variable to make it available with the __finally clause.

Allows Boost.Test to be built with clang on windows, in VC compatibility mode.