### PR TITLE
Fix for uClibc and gcc <= 4.8.2

### DIFF
--- a/include/boost/test/impl/unit_test_main.ipp
+++ b/include/boost/test/impl/unit_test_main.ipp
@@ -191,7 +191,9 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
         if( runtime_config::get<bool>( runtime_config::WAIT_FOR_DEBUGGER ) ) {
             results_reporter::get_stream() << "Press any key to continue..." << std::endl;
 
-            std::getchar();
+            // getchar is defined as a macro in uClibc. Use parenthesis to fix
+            // gcc bug 58952 for gcc <= 4.8.2.
+            (std::getchar)();
             results_reporter::get_stream() << "Continuing..." << std::endl;
         }
 


### PR DESCRIPTION
getchar() is defined as a macro in uClibc. This hits gcc bug 58952 [1] for all
gcc version <= 4.8.2 and building boost/test fails:

```
./boost/test/impl/unit_test_main.ipp: In function 'int boost::unit_test::unit_test_main(boost::unit_test::init_unit_test_func, int, char**)':
./boost/test/impl/unit_test_main.ipp:194:18: error: expected unqualified-id before '(' token
```

To allow building boost/test with uClibc based toolchains with gcc <= 4.8.2 use
parenthesis for std::getchar.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58952