### PR TITLE
fix ticket number

### DIFF
--- a/doc/closing_chapters/change_log.qbk
+++ b/doc/closing_chapters/change_log.qbk
@@ -19,7 +19,7 @@
 [h5 Bugfixes and feature requests]
 # [ticket 6767] Use of namespace qualifier with floating point exception functions breaks if they are macros
 # [ticket 8905] `boost/test/impl/debug.ipp`: Ignores return value from `WaitForSingleObject`
-# [ticket 9943] Runtime parameter Random seed for random order of test cases not respected correctly
+# [ticket 9443] Runtime parameter Random seed for random order of test cases not respected correctly
 # [ticket 11854] Add fixture support in `BOOST_DATA_TEST_CASE`
 # [ticket 11887] `BOOST_TEST(3u == (std::max)(0u, 3u))` fails
 # [ticket 11889] `BOOST_DATA_TEST_CASE` fails to compile for 4D and higher dimensional grids


### PR DESCRIPTION
9943 is MSM's ticket. Correct ticket number is 9443.
https://svn.boost.org/trac/boost/ticket/9443

If the fix is correctly, please fix release note of boostorg/website.