### PR TITLE
Allow joins to properly join grids

### DIFF
--- a/include/boost/test/data/for_each_sample.hpp
+++ b/include/boost/test/data/for_each_sample.hpp
@@ -63,7 +63,7 @@ invoke_action( Action const& action, T&& args, std::true_type /* is_tuple */ )
 {
     invoke_action_impl( action,
                         std::forward<T>(args),
-                        typename make_index_sequence< 0, std::tuple_size<T>::value >::type{} );
+                        typename make_index_sequence< 0, std::tuple_size<std::decay_t<T>>::value >::type{} );
 
 }
 

--- a/include/boost/test/data/monomorphic/join.hpp
+++ b/include/boost/test/data/monomorphic/join.hpp
@@ -41,8 +41,6 @@ class join {
     typedef typename dataset1_decay::iterator       dataset1_iter;
     typedef typename dataset2_decay::iterator       dataset2_iter;
 public:
-    typedef typename dataset1_decay::sample         sample;
-
     enum { arity = dataset1_decay::arity };
 
     struct iterator {
@@ -54,7 +52,7 @@ public:
         {}
 
         // forward iterator interface
-        sample const&       operator*() const   { return m_first_size > 0 ? *m_it1 : *m_it2; }
+        decltype(auto)      operator*() const   { return m_first_size > 0 ? *m_it1 : *m_it2; }
         void                operator++()        { if( m_first_size > 0 ) { --m_first_size; ++m_it1; } else ++m_it2; }
 
     private:


### PR DESCRIPTION
Joining two grids (of the same arity) would formerly cause a compiler
error.

See Trac #12216
