### PR TITLE
Syntactic change silences latest gcc warnings

### DIFF
--- a/include/boost/test/tools/fpc_op.hpp
+++ b/include/boost/test/tools/fpc_op.hpp
@@ -178,16 +178,22 @@ public:                                                                 \
     eval( Lhs const& lhs, Rhs const& rhs )                              \
     {                                                                   \
         if( lhs == 0 )                                                  \
+            {                                                           \
             return compare_fpv_near_zero( rhs, (OP*)0 );                \
+            }                                                           \
                                                                         \
         if( rhs == 0 )                                                  \
+            {                                                           \
             return compare_fpv_near_zero( lhs, (OP*)0 );                \
+            }                                                           \
                                                                         \
         bool direct_res = eval_direct( lhs, rhs );                      \
                                                                         \
         if( (direct_res && fpctraits<OP>::cmp_direct) ||                \
             fpc_tolerance<FPT>() == FPT(0) )                            \
+            {                                                           \
             return direct_res;                                          \
+            }                                                           \
                                                                         \
         return compare_fpv<FPT>( lhs, rhs, (OP*)0 );                    \
     }                                                                   \


### PR DESCRIPTION
Gcc issues warnings whenever it encounters the expansion of the macro, claiming the 'if' statements could be confusing. This purely syntactical change of removing the 'if' one liners in favor of the 'if' block silences the warnings.