### PR TITLE
Fix gcc's warning/error when building with -Wmisleading-indentation

### DIFF
--- a/include/boost/test/tools/fpc_op.hpp
+++ b/include/boost/test/tools/fpc_op.hpp
@@ -178,16 +178,22 @@ public:                                                                 \
     eval( Lhs const& lhs, Rhs const& rhs )                              \
     {                                                                   \
         if( lhs == 0 )                                                  \
+        {                                                               \
             return compare_fpv_near_zero( rhs, (OP*)0 );                \
+        }                                                               \
                                                                         \
         if( rhs == 0 )                                                  \
+        {                                                               \
             return compare_fpv_near_zero( lhs, (OP*)0 );                \
+        }                                                               \
                                                                         \
         bool direct_res = eval_direct( lhs, rhs );                      \
                                                                         \
         if( (direct_res && fpctraits<OP>::cmp_direct) ||                \
             fpc_tolerance<FPT>() == FPT(0) )                            \
+        {                                                               \
             return direct_res;                                          \
+        }                                                               \
                                                                         \
         return compare_fpv<FPT>( lhs, rhs, (OP*)0 );                    \
     }                                                                   \


### PR DESCRIPTION
Hi,

I am having troubles when including "boost/test/unit_test.hpp" with gcc 6 and -Wall -Werror turned on. gcc (wrongly) complains about misleading indentation in the macro DEFINE_FPV_COMPARISON. This is likely caused by the fact that we have extra indentation after each line so that the backlslashes are properly aligned, and the macro is eventually putting this on a single line. Anyway, an easy fix is to use braces around all block of code.

Ok for the merge ?

(Similar to https://github.com/boostorg/spirit/pull/222)

Cheers,
Romain