### PR TITLE
Fix unused parameter warnings/errors with gcc 6.

### DIFF
--- a/include/boost/test/unit_test_log_formatter.hpp
+++ b/include/boost/test/unit_test_log_formatter.hpp
@@ -165,16 +165,16 @@ public:
     /// @param[in] os   output stream to write a messages into
     /// @param[in] tu   skipped test unit
     /// @param[in] reason explanation why was it skipped
-    virtual void        test_unit_skipped( std::ostream& os, test_unit const& tu, const_string reason )
+    virtual void        test_unit_skipped( std::ostream& os, test_unit const& tu, const_string /* reason */)
     {
         test_unit_skipped( os, tu );
     }
 
     /// Deprecated version of this interface
-    virtual void        test_unit_skipped( std::ostream& os, test_unit const& tu ) {}
+    virtual void        test_unit_skipped( std::ostream& /* os */, test_unit const& /* tu */) {}
 
     /// Invoked when a test unit is aborted
-    virtual void        test_unit_aborted( std::ostream& os, test_unit const& tu ) {}
+    virtual void        test_unit_aborted( std::ostream& /* os */, test_unit const& /* tu */) {}
 
     // @}
 

--- a/include/boost/test/utils/runtime/parameter.hpp
+++ b/include/boost/test/utils/runtime/parameter.hpp
@@ -220,7 +220,7 @@ protected:
 
 private:
     /// interface for usage/help customization
-    virtual void            cla_name_help( std::ostream& ostr, cstring cla_tag, cstring negation_prefix_ ) const
+    virtual void            cla_name_help( std::ostream& ostr, cstring cla_tag, cstring /* negation_prefix_ */) const
     {
         ostr << cla_tag;
     }


### PR DESCRIPTION
Hi,

I have just hit a couple of "unused parameter" warnings that in my case are errors since I build with -Werror.

Ok to merge ?

Cheers,
Romain