### PR TITLE
Change capital variable names to lowercase

### DIFF
--- a/doc/examples/example51.run.cpp
+++ b/doc/examples/example51.run.cpp
@@ -13,7 +13,7 @@ using namespace boost::unit_test;
 
 BOOST_AUTO_TEST_CASE( test_case0 )
 {
-  if( runtime_config::get<log_level>( runtime_config::LOG_LEVEL ) < log_warnings )
+  if( runtime_config::get<log_level>( runtime_config::log_level_str ) < log_warnings )
     unit_test_log.set_threshold_level( log_warnings );
 
   BOOST_WARN( sizeof(int) > 4 );

--- a/include/boost/test/impl/compiler_log_formatter.ipp
+++ b/include/boost/test/impl/compiler_log_formatter.ipp
@@ -62,7 +62,7 @@ test_phase_identifier()
 void
 compiler_log_formatter::log_start( std::ostream& output, counter_t test_cases_amount )
 {
-    m_color_output = runtime_config::get<bool>( runtime_config::COLOR_OUTPUT );
+    m_color_output = runtime_config::get<bool>( runtime_config::color_output_str );
 
     if( test_cases_amount > 0 )
         output  << "Running " << test_cases_amount << " test "

--- a/include/boost/test/impl/framework.ipp
+++ b/include/boost/test/impl/framework.ipp
@@ -396,7 +396,7 @@ parse_filters( test_unit_id master_tu_id, test_unit_id_list& tu_to_enable, test_
     // 10. collect tu to enable and disable based on filters
     bool had_selector_filter = false;
 
-    std::vector<std::string> const& filters = runtime_config::get<std::vector<std::string> >( runtime_config::RUN_FILTERS );
+    std::vector<std::string> const& filters = runtime_config::get<std::vector<std::string> >( runtime_config::run_filters_str );
 
     BOOST_TEST_FOREACH( const_string, filter, filters ) {
         BOOST_TEST_SETUP_ASSERT( !filter.is_empty(), "Invalid filter specification" );
@@ -552,7 +552,7 @@ public:
         test_unit_id_list tu_to_disable;
 
         // 10. If there are any filters supplied, figure out lists of test units to enable/disable
-        bool had_selector_filter = !runtime_config::get<std::vector<std::string> >( runtime_config::RUN_FILTERS ).empty() &&
+        bool had_selector_filter = !runtime_config::get<std::vector<std::string> >( runtime_config::run_filters_str ).empty() &&
                                    parse_filters( master_tu_id, tu_to_enable, tu_to_disable );
 
         // 20. Set the stage: either use default run status or disable all test units
@@ -657,7 +657,7 @@ public:
             if( tu.p_type == TUT_SUITE ) {
                 test_suite const& ts = static_cast<test_suite const&>( tu );
 
-                if( runtime_config::get<unsigned>( runtime_config::RANDOM_SEED ) == 0 ) {
+                if( runtime_config::get<unsigned>( runtime_config::random_seed_str ) == 0 ) {
                     typedef std::pair<counter_t,test_unit_id> value_type;
 
                     BOOST_TEST_FOREACH( value_type, chld, ts.m_ranked_children ) {
@@ -845,26 +845,26 @@ setup_loggers()
     BOOST_TEST_I_TRY {
 
 #ifdef BOOST_TEST_SUPPORT_TOKEN_ITERATOR
-        bool has_combined_logger = runtime_config::has( runtime_config::COMBINED_LOGGER )
-            && !runtime_config::get< std::vector<std::string> >( runtime_config::COMBINED_LOGGER ).empty();
+        bool has_combined_logger = runtime_config::has( runtime_config::combined_logger_str )
+            && !runtime_config::get< std::vector<std::string> >( runtime_config::combined_logger_str ).empty();
 #else
         bool has_combined_logger = false;
 #endif
 
         if( !has_combined_logger ) {
-            unit_test_log.set_threshold_level( runtime_config::get<log_level>( runtime_config::LOG_LEVEL ) );
-            const output_format format = runtime_config::get<output_format>( runtime_config::LOG_FORMAT );
+            unit_test_log.set_threshold_level( runtime_config::get<log_level>( runtime_config::log_level_str ) );
+            const output_format format = runtime_config::get<output_format>( runtime_config::log_format_str );
             unit_test_log.set_format( format );
 
             runtime_config::stream_holder& stream_logger = s_frk_state().m_log_sinks[format];
-            if( runtime_config::has( runtime_config::LOG_SINK ) )
-                stream_logger.setup( runtime_config::get<std::string>( runtime_config::LOG_SINK ) );
+            if( runtime_config::has( runtime_config::log_sink_str ) )
+                stream_logger.setup( runtime_config::get<std::string>( runtime_config::log_sink_str ) );
             unit_test_log.set_stream( stream_logger.ref() );
         }
         else
         {
 
-            const std::vector<std::string>& v_output_format = runtime_config::get< std::vector<std::string> >( runtime_config::COMBINED_LOGGER ) ;
+            const std::vector<std::string>& v_output_format = runtime_config::get< std::vector<std::string> >( runtime_config::combined_logger_str ) ;
 
             static const std::pair<const char*, log_level> all_log_levels[] = {
                 std::make_pair( "all"           , log_successful_tests ),
@@ -1033,26 +1033,26 @@ init( init_unit_test_func init_func, int argc, char* argv[] )
     impl::setup_loggers();
 
     // 30. Set the desired report level, format and sink
-    results_reporter::set_level( runtime_config::get<report_level>( runtime_config::REPORT_LEVEL ) );
-    results_reporter::set_format( runtime_config::get<output_format>( runtime_config::REPORT_FORMAT ) );
+    results_reporter::set_level( runtime_config::get<report_level>( runtime_config::report_level_str ) );
+    results_reporter::set_format( runtime_config::get<output_format>( runtime_config::report_format_str ) );
 
-    if( runtime_config::has( runtime_config::REPORT_SINK ) )
-        s_frk_state().m_report_sink.setup( runtime_config::get<std::string>( runtime_config::REPORT_SINK ) );
+    if( runtime_config::has( runtime_config::report_sink_str ) )
+        s_frk_state().m_report_sink.setup( runtime_config::get<std::string>( runtime_config::report_sink_str ) );
     results_reporter::set_stream( s_frk_state().m_report_sink.ref() );
 
     // 40. Register default test observers
     register_observer( results_collector );
     register_observer( unit_test_log );
 
-    if( runtime_config::get<bool>( runtime_config::SHOW_PROGRESS ) ) {
+    if( runtime_config::get<bool>( runtime_config::show_progress_str ) ) {
         progress_monitor.set_stream( std::cout ); // defaults to stdout
         register_observer( progress_monitor );
     }
 
     // 50. Set up memory leak detection
-    unsigned long detect_mem_leak = runtime_config::get<unsigned long>( runtime_config::DETECT_MEM_LEAKS );
+    unsigned long detect_mem_leak = runtime_config::get<unsigned long>( runtime_config::detect_mem_leaks_str );
     if( detect_mem_leak > 0 ) {
-        debug::detect_memory_leaks( true, runtime_config::get<std::string>( runtime_config::REPORT_MEM_LEAKS ) );
+        debug::detect_memory_leaks( true, runtime_config::get<std::string>( runtime_config::report_mem_leaks_str ) );
         debug::break_memory_alloc( (long)detect_mem_leak );
     }
 
@@ -1408,7 +1408,7 @@ run( test_unit_id id, bool continue_test )
     test_case_counter tcc;
     traverse_test_tree( id, tcc );
 
-    BOOST_TEST_SETUP_ASSERT( tcc.p_count != 0 , runtime_config::get<std::vector<std::string> >( runtime_config::RUN_FILTERS ).empty()
+    BOOST_TEST_SETUP_ASSERT( tcc.p_count != 0 , runtime_config::get<std::vector<std::string> >( runtime_config::run_filters_str ).empty()
         ? BOOST_TEST_L( "test tree is empty" )
         : BOOST_TEST_L( "no test cases matching filter or all test cases were disabled" ) );
 
@@ -1428,7 +1428,7 @@ run( test_unit_id id, bool continue_test )
         }
     }
 
-    unsigned seed = runtime_config::get<unsigned>( runtime_config::RANDOM_SEED );
+    unsigned seed = runtime_config::get<unsigned>( runtime_config::random_seed_str );
     switch( seed ) {
     case 0:
         break;

--- a/include/boost/test/impl/plain_report_formatter.ipp
+++ b/include/boost/test/impl/plain_report_formatter.ipp
@@ -83,7 +83,7 @@ void
 plain_report_formatter::results_report_start( std::ostream& ostr )
 {
     m_indent = 0;
-    m_color_output = runtime_config::get<bool>( runtime_config::COLOR_OUTPUT );
+    m_color_output = runtime_config::get<bool>( runtime_config::color_output_str );
     ostr << '\n';
 }
 

--- a/include/boost/test/impl/progress_monitor.ipp
+++ b/include/boost/test/impl/progress_monitor.ipp
@@ -124,7 +124,7 @@ progress_monitor_impl& s_pm_impl() { static progress_monitor_impl the_inst; retu
 void
 progress_monitor_t::test_start( counter_t test_cases_amount )
 {
-    s_pm_impl().m_color_output = runtime_config::get<bool>( runtime_config::COLOR_OUTPUT );
+    s_pm_impl().m_color_output = runtime_config::get<bool>( runtime_config::color_output_str );
 
     PM_SCOPED_COLOR();
 

--- a/include/boost/test/impl/unit_test_log.ipp
+++ b/include/boost/test/impl/unit_test_log.ipp
@@ -168,7 +168,7 @@ unit_test_log_t::test_start( counter_t test_cases_amount )
 
       current_logger_data.m_log_formatter->log_start( current_logger_data.stream(), test_cases_amount );
 
-      if( runtime_config::get<bool>( runtime_config::BUILD_INFO ) )
+      if( runtime_config::get<bool>( runtime_config::build_info_str ) )
           current_logger_data.m_log_formatter->log_build_info( current_logger_data.stream() );
 
       current_logger_data.m_entry_in_progress = false;

--- a/include/boost/test/impl/unit_test_main.ipp
+++ b/include/boost/test/impl/unit_test_main.ipp
@@ -188,7 +188,7 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
     BOOST_TEST_I_TRY {
         framework::init( init_func, argc, argv );
 
-        if( runtime_config::get<bool>( runtime_config::WAIT_FOR_DEBUGGER ) ) {
+        if( runtime_config::get<bool>( runtime_config::wait_for_debugger_str ) ) {
             results_reporter::get_stream() << "Press any key to continue..." << std::endl;
 
             // getchar is defined as a macro in uClibc. Use parenthesis to fix
@@ -199,7 +199,7 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
 
         framework::finalize_setup_phase();
 
-        output_format list_cont = runtime_config::get<output_format>( runtime_config::LIST_CONTENT );
+        output_format list_cont = runtime_config::get<output_format>( runtime_config::list_content_str );
         if( list_cont != unit_test::OF_INVALID ) {
             if( list_cont == unit_test::OF_DOT ) {
                 ut_detail::dot_content_reporter reporter( results_reporter::get_stream() );
@@ -215,7 +215,7 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
             return boost::exit_success;
         }
 
-        if( runtime_config::get<bool>( runtime_config::LIST_LABELS ) ) {
+        if( runtime_config::get<bool>( runtime_config::list_labels_str ) ) {
             ut_detail::labels_collector collector;
 
             traverse_test_tree( framework::master_test_suite().p_id, collector, true );
@@ -232,7 +232,7 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
 
         results_reporter::make_report();
 
-        result_code = !runtime_config::get<bool>( runtime_config::RESULT_CODE )
+        result_code = !runtime_config::get<bool>( runtime_config::result_code_str )
                         ? boost::exit_success
                         : results_collector.results( framework::master_test_suite().p_id ).result_code();
     }

--- a/include/boost/test/impl/unit_test_monitor.ipp
+++ b/include/boost/test/impl/unit_test_monitor.ipp
@@ -37,11 +37,11 @@ unit_test_monitor_t::error_level
 unit_test_monitor_t::execute_and_translate( boost::function<void ()> const& func, unsigned timeout )
 {
     BOOST_TEST_I_TRY {
-        p_catch_system_errors.value     = runtime_config::get<bool>( runtime_config::CATCH_SYS_ERRORS );
+        p_catch_system_errors.value     = runtime_config::get<bool>( runtime_config::catch_sys_errors_str );
         p_timeout.value                 = timeout;
-        p_auto_start_dbg.value          = runtime_config::get<bool>( runtime_config::AUTO_START_DBG );
-        p_use_alt_stack.value           = runtime_config::get<bool>( runtime_config::USE_ALT_STACK );
-        p_detect_fp_exceptions.value    = runtime_config::get<bool>( runtime_config::DETECT_FP_EXCEPT );
+        p_auto_start_dbg.value          = runtime_config::get<bool>( runtime_config::auto_start_dbg_str );
+        p_use_alt_stack.value           = runtime_config::get<bool>( runtime_config::use_alt_stack_str );
+        p_detect_fp_exceptions.value    = runtime_config::get<bool>( runtime_config::detect_fp_except_str );
 
         vexecute( func );
     }

--- a/include/boost/test/impl/unit_test_parameters.ipp
+++ b/include/boost/test/impl/unit_test_parameters.ipp
@@ -71,35 +71,35 @@ namespace rt = boost::runtime;
 namespace runtime_config {
 
 // UTF parameters
-std::string AUTO_START_DBG    = "auto_start_dbg";
-std::string BREAK_EXEC_PATH   = "break_exec_path";
-std::string BUILD_INFO        = "build_info";
-std::string CATCH_SYS_ERRORS  = "catch_system_errors";
-std::string COLOR_OUTPUT      = "color_output";
-std::string DETECT_FP_EXCEPT  = "detect_fp_exceptions";
-std::string DETECT_MEM_LEAKS  = "detect_memory_leaks";
-std::string LIST_CONTENT      = "list_content";
-std::string LIST_LABELS       = "list_labels";
-std::string LOG_FORMAT        = "log_format";
-std::string LOG_LEVEL         = "log_level";
-std::string LOG_SINK          = "log_sink";
-std::string COMBINED_LOGGER   = "logger";
-std::string OUTPUT_FORMAT     = "output_format";
-std::string RANDOM_SEED       = "random";
-std::string REPORT_FORMAT     = "report_format";
-std::string REPORT_LEVEL      = "report_level";
-std::string REPORT_MEM_LEAKS  = "report_memory_leaks_to";
-std::string REPORT_SINK       = "report_sink";
-std::string RESULT_CODE       = "result_code";
-std::string RUN_FILTERS       = "run_test";
-std::string SAVE_TEST_PATTERN = "save_pattern";
-std::string SHOW_PROGRESS     = "show_progress";
-std::string USE_ALT_STACK     = "use_alt_stack";
-std::string WAIT_FOR_DEBUGGER = "wait_for_debugger";
+std::string auto_start_dbg_str    = "auto_start_dbg";
+std::string break_exec_path_str   = "break_exec_path";
+std::string build_info_str        = "build_info";
+std::string catch_sys_errors_str  = "catch_system_errors";
+std::string color_output_str      = "color_output";
+std::string detect_fp_except_str  = "detect_fp_exceptions";
+std::string detect_mem_leaks_str  = "detect_memory_leaks";
+std::string list_content_str      = "list_content";
+std::string list_labels_str       = "list_labels";
+std::string log_format_str        = "log_format";
+std::string log_level_str         = "log_level";
+std::string log_sink_str          = "log_sink";
+std::string combined_logger_str   = "logger";
+std::string output_format_str     = "output_format";
+std::string random_seed_str       = "random";
+std::string report_format_str     = "report_format";
+std::string report_level_str      = "report_level";
+std::string report_mem_leaks_str  = "report_memory_leaks_to";
+std::string report_sink_str       = "report_sink";
+std::string result_code_str       = "result_code";
+std::string run_filters_str       = "run_test";
+std::string save_test_pattern_str = "save_pattern";
+std::string show_progress_str     = "show_progress";
+std::string use_alt_stack_str     = "use_alt_stack";
+std::string wait_for_debugger_str = "wait_for_debugger";
 
-std::string HELP              = "help";
-std::string USAGE             = "usage";
-std::string VERSION           = "version";
+std::string help_str              = "help";
+std::string usage_str             = "usage";
+std::string version_str           = "version";
 
 //____________________________________________________________________________//
 
@@ -108,11 +108,11 @@ namespace {
 void
 register_parameters( rt::parameters_store& store )
 {
-    rt::option auto_start_dbg( AUTO_START_DBG, (
+    rt::option auto_start_dbg( auto_start_dbg_str, (
         rt::description = "Automatically attaches debugger in case of system level failure (signal).",
         rt::env_var = "BOOST_TEST_AUTO_START_DBG",
 
-        rt::help = "Option " + AUTO_START_DBG + " specifies whether Boost.Test should attempt "
+        rt::help = "Option " + auto_start_dbg_str + " specifies whether Boost.Test should attempt "
                    "to attach a debugger when fatal system error occurs. At the moment this feature "
                    "is only available on a few selected platforms: Win32 and *nix. There is a "
                    "default debugger configured for these platforms. You can manually configure "
@@ -120,13 +120,13 @@ register_parameters( rt::parameters_store& store )
                    "Boost.Test debug API, specifically the function boost::debug::set_debugger."
     ));
 
-    auto_start_dbg.add_cla_id( "--", AUTO_START_DBG, "=" );
+    auto_start_dbg.add_cla_id( "--", auto_start_dbg_str, "=" );
     auto_start_dbg.add_cla_id( "-", "d", " " );
     store.add( auto_start_dbg );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string> break_exec_path( BREAK_EXEC_PATH, (
+    rt::parameter<std::string> break_exec_path( break_exec_path_str, (
         rt::description = "For the exception safety testing allows to break at specific execution path.",
         rt::env_var = "BOOST_TEST_BREAK_EXEC_PATH"
 #ifndef BOOST_NO_CXX11_LAMBDAS
@@ -137,25 +137,25 @@ register_parameters( rt::parameters_store& store )
 #endif
     ));
 
-    break_exec_path.add_cla_id( "--", BREAK_EXEC_PATH, "=" );
+    break_exec_path.add_cla_id( "--", break_exec_path_str, "=" );
     store.add( break_exec_path );
 
     ///////////////////////////////////////////////
 
-    rt::option build_info( BUILD_INFO, (
+    rt::option build_info( build_info_str, (
         rt::description = "Displays library build information.",
         rt::env_var = "BOOST_TEST_BUILD_INFO",
-        rt::help = "Option " + BUILD_INFO + " displays library build information, including: platform, "
+        rt::help = "Option " + build_info_str + " displays library build information, including: platform, "
                    "compiler, STL version and Boost version."
     ));
 
-    build_info.add_cla_id( "--", BUILD_INFO, "=" );
+    build_info.add_cla_id( "--", build_info_str, "=" );
     build_info.add_cla_id( "-", "i", " " );
     store.add( build_info );
 
     ///////////////////////////////////////////////
 
-    rt::option catch_sys_errors( CATCH_SYS_ERRORS, (
+    rt::option catch_sys_errors( catch_sys_errors_str, (
         rt::description = "Allows to switch between catching and ignoring system errors (signals).",
         rt::env_var = "BOOST_TEST_CATCH_SYSTEM_ERRORS",
         rt::default_value =
@@ -164,7 +164,7 @@ register_parameters( rt::parameters_store& store )
 #else
             true,
 #endif
-        rt::help = "If option " + CATCH_SYS_ERRORS + " has value no the frameworks does not attempt to catch "
+        rt::help = "If option " + catch_sys_errors_str + " has value no the frameworks does not attempt to catch "
                    "asynchronous system failure events (signals on *NIX platforms or structured exceptions on Windows). "
                    " Default value is "
 #ifdef BOOST_TEST_DEFAULTS_TO_CORE_DUMP
@@ -174,13 +174,13 @@ register_parameters( rt::parameters_store& store )
 #endif
     ));
 
-    catch_sys_errors.add_cla_id( "--", CATCH_SYS_ERRORS, "=", true );
+    catch_sys_errors.add_cla_id( "--", catch_sys_errors_str, "=", true );
     catch_sys_errors.add_cla_id( "-", "s", " " );
     store.add( catch_sys_errors );
 
     ///////////////////////////////////////////////
 
-    rt::option color_output( COLOR_OUTPUT, (
+    rt::option color_output( color_output_str, (
         rt::description = "Enables color output of the framework log and report messages.",
         rt::env_var = "BOOST_TEST_COLOR_OUTPUT",
         rt::help = "The framework is able to produce color output on systems which supports it. "
@@ -188,31 +188,31 @@ register_parameters( rt::parameters_store& store )
                    "does not produces color output."
     ));
 
-    color_output.add_cla_id( "--", COLOR_OUTPUT, "=", true );
+    color_output.add_cla_id( "--", color_output_str, "=", true );
     color_output.add_cla_id( "-", "x", " " );
     store.add( color_output );
 
     ///////////////////////////////////////////////
 
-    rt::option detect_fp_except( DETECT_FP_EXCEPT, (
+    rt::option detect_fp_except( detect_fp_except_str, (
         rt::description = "Enables/disables floating point exceptions traps.",
         rt::env_var = "BOOST_TEST_DETECT_FP_EXCEPTIONS",
-        rt::help = "Option " + DETECT_FP_EXCEPT + " enables/disables hardware traps for the floating "
+        rt::help = "Option " + detect_fp_except_str + " enables/disables hardware traps for the floating "
                    "point exceptions (if supported on your platfrom)."
     ));
 
-    detect_fp_except.add_cla_id( "--", DETECT_FP_EXCEPT, "=", true );
+    detect_fp_except.add_cla_id( "--", detect_fp_except_str, "=", true );
     store.add( detect_fp_except );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<unsigned long> detect_mem_leaks( DETECT_MEM_LEAKS, (
+    rt::parameter<unsigned long> detect_mem_leaks( detect_mem_leaks_str, (
         rt::description = "Turns on/off memory leaks detection (optionally breaking on specified alloc order number).",
         rt::env_var = "BOOST_TEST_DETECT_MEMORY_LEAK",
         rt::default_value = 1L,
         rt::optional_value = 1L,
         rt::value_hint = "<alloc order number>",
-        rt::help = "Parameter " + DETECT_MEM_LEAKS + " enables/disables memory leaks detection. "
+        rt::help = "Parameter " + detect_mem_leaks_str + " enables/disables memory leaks detection. "
                    "This parameter has optional long integer value. The default value is 1, which "
                    "enables the memory leak detection. The value 0 disables memory leak detection. "
                    "Any value N greater than 1 is treated as leak allocation number and tells the "
@@ -220,12 +220,12 @@ register_parameters( rt::parameters_store& store )
                    "omitted the default value is assumed."
     ));
 
-    detect_mem_leaks.add_cla_id( "--", DETECT_MEM_LEAKS, "=" );
+    detect_mem_leaks.add_cla_id( "--", detect_mem_leaks_str, "=" );
     store.add( detect_mem_leaks );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::output_format> list_content( LIST_CONTENT, (
+    rt::enum_parameter<unit_test::output_format> list_content( list_content_str, (
         rt::description = "Lists the content of test tree - names of all test suites and test cases.",
         rt::env_var = "BOOST_TEST_LIST_CONTENT",
         rt::default_value = OF_INVALID,
@@ -242,30 +242,30 @@ register_parameters( rt::parameters_store& store )
             ( "DOT", OF_DOT )
         ,
 #endif
-        rt::help = "Parameter " + LIST_CONTENT + " instructs the framework to list the content "
+        rt::help = "Parameter " + list_content_str + " instructs the framework to list the content "
                    "of the test module instead of executing the test cases. Parameter accepts "
                    "optional string value indicating the format of the output. Currently the "
                    "framework supports two formats: human readable format (HRF) and dot graph "
                    "format (DOT). If value is omitted HRF value is assumed."
     ));
-    list_content.add_cla_id( "--", LIST_CONTENT, "=" );
+    list_content.add_cla_id( "--", list_content_str, "=" );
     store.add( list_content );
 
     ///////////////////////////////////////////////
 
-    rt::option list_labels( LIST_LABELS, (
+    rt::option list_labels( list_labels_str, (
         rt::description = "Lists all available labels.",
         rt::env_var = "BOOST_TEST_LIST_LABELS",
-        rt::help = "Option " + LIST_LABELS + " instructs the framework to list all the the labels "
+        rt::help = "Option " + list_labels_str + " instructs the framework to list all the the labels "
                    "defined in the test module instead of executing the test cases."
     ));
 
-    list_labels.add_cla_id( "--", LIST_LABELS, "=" );
+    list_labels.add_cla_id( "--", list_labels_str, "=" );
     store.add( list_labels );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::output_format> log_format( LOG_FORMAT, (
+    rt::enum_parameter<unit_test::output_format> log_format( log_format_str, (
         rt::description = "Specifies log format.",
         rt::env_var = "BOOST_TEST_LOG_FORMAT",
         rt::default_value = OF_CLF,
@@ -285,7 +285,7 @@ register_parameters( rt::parameters_store& store )
             ( "JUNIT", OF_JUNIT )
         ,
 #endif
-        rt::help = "Parameter " + LOG_FORMAT + " allows to set the frameowrk's log format to one "
+        rt::help = "Parameter " + log_format_str + " allows to set the frameowrk's log format to one "
                    "of the formats supplied by the framework. The only acceptable values for this "
                    "parameter are the names of the output formats supplied by the framework. By "
                    "default the framework uses human readable format (HRF) for testing log. This "
@@ -293,13 +293,13 @@ register_parameters( rt::parameters_store& store )
                    "or JUNIT as log format, which are easier to process by testing automation tools."
     ));
 
-    log_format.add_cla_id( "--", LOG_FORMAT, "=" );
+    log_format.add_cla_id( "--", log_format_str, "=" );
     log_format.add_cla_id( "-", "f", " " );
     store.add( log_format );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::log_level> log_level( LOG_LEVEL, (
+    rt::enum_parameter<unit_test::log_level> log_level( log_level_str, (
         rt::description = "Specifies log level.",
         rt::env_var = "BOOST_TEST_LOG_LEVEL",
         rt::default_value = log_all_errors,
@@ -333,7 +333,7 @@ register_parameters( rt::parameters_store& store )
             ( "nothing"       , log_nothing )
         ,
 #endif
-        rt::help = "Parameter " + LOG_LEVEL + " allows to set the framework's log level. "
+        rt::help = "Parameter " + log_level_str + " allows to set the framework's log level. "
                    "Log level defines the verbosity of testing log produced by a testing "
                    "module. The verbosity ranges from a complete log, when all assertions "
                    "(both successful and failing) are reported, all notifications about "
@@ -341,29 +341,29 @@ register_parameters( rt::parameters_store& store )
                    "is reported to a testing log stream."
     ));
 
-    log_level.add_cla_id( "--", LOG_LEVEL, "=" );
+    log_level.add_cla_id( "--", log_level_str, "=" );
     log_level.add_cla_id( "-", "l", " " );
     store.add( log_level );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string> log_sink( LOG_SINK, (
+    rt::parameter<std::string> log_sink( log_sink_str, (
         rt::description = "Specifies log sink: stdout(default), stderr or file name.",
         rt::env_var = "BOOST_TEST_LOG_SINK",
         rt::value_hint = "<stderr|stdout|file name>",
-        rt::help = "Parameter " + LOG_SINK + " allows to set the log sink - location "
+        rt::help = "Parameter " + log_sink_str + " allows to set the log sink - location "
                    "where we report the log to, thus it allows to easily redirect the "
                    "test logs to file or standard streams. By default testing log is "
                    "directed to standard output."
     ));
 
-    log_sink.add_cla_id( "--", LOG_SINK, "=" );
+    log_sink.add_cla_id( "--", log_sink_str, "=" );
     log_sink.add_cla_id( "-", "k", " " );
     store.add( log_sink );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::output_format> output_format( OUTPUT_FORMAT, (
+    rt::enum_parameter<unit_test::output_format> output_format( output_format_str, (
         rt::description = "Specifies output format (both log and report).",
         rt::env_var = "BOOST_TEST_OUTPUT_FORMAT",
         rt::enum_values<unit_test::output_format>::value =
@@ -380,8 +380,8 @@ register_parameters( rt::parameters_store& store )
             ( "XML", OF_XML )
         ,
 #endif
-        rt::help = "Parameter " + OUTPUT_FORMAT + " combines an effect of " + REPORT_FORMAT +
-                   " and " + LOG_FORMAT + " parameters. This parameter has higher priority "
+        rt::help = "Parameter " + output_format_str + " combines an effect of " + report_format_str +
+                   " and " + log_format_str + " parameters. This parameter has higher priority "
                    "than either one of them. In other words if this parameter is specified "
                    "it overrides the value of other two parameters. This parameter does not "
                    "have a default value. The only acceptable values are string names of "
@@ -389,33 +389,33 @@ register_parameters( rt::parameters_store& store )
                    "automation tools processing."
     ));
 
-    output_format.add_cla_id( "--", OUTPUT_FORMAT, "=" );
+    output_format.add_cla_id( "--", output_format_str, "=" );
     output_format.add_cla_id( "-", "o", " " );
     store.add( output_format );
 
     /////////////////////////////////////////////// combined logger option
 
-    rt::parameter<std::string,rt::REPEATABLE_PARAM> combined_logger( COMBINED_LOGGER, (
+    rt::parameter<std::string,rt::REPEATABLE_PARAM> combined_logger( combined_logger_str, (
         rt::description = "Specifies log level and sink for one or several log format",
         rt::env_var = "BOOST_TEST_LOGGER",
         rt::value_hint = "log_format:log_level:log_sink",
-        rt::help = "Parameter " + COMBINED_LOGGER + " allows to specify the logger type, level and sink\n"
+        rt::help = "Parameter " + combined_logger_str + " allows to specify the logger type, level and sink\n"
                    "in one command."
     ));
 
-    combined_logger.add_cla_id( "--", COMBINED_LOGGER, "=" );
+    combined_logger.add_cla_id( "--", combined_logger_str, "=" );
     store.add( combined_logger );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<unsigned> random_seed( RANDOM_SEED, (
+    rt::parameter<unsigned> random_seed( random_seed_str, (
         rt::description = "Allows to switch between sequential and random order of test units execution."
                           " Optionally allows to specify concrete seed for random number generator.",
         rt::env_var = "BOOST_TEST_RANDOM",
         rt::default_value = 0U,
         rt::optional_value = 1U,
         rt::value_hint = "<seed>",
-        rt::help = "Parameter " + RANDOM_SEED + " instructs the framework to execute the "
+        rt::help = "Parameter " + random_seed_str + " instructs the framework to execute the "
                    "test cases in random order. This parameter accepts optional unsigned "
                    "integer argument. By default test cases are executed in some specific "
                    "order defined by order of test units in test files and dependency between "
@@ -425,12 +425,12 @@ register_parameters( rt::parameters_store& store )
                    "the run."
     ));
 
-    random_seed.add_cla_id( "--", RANDOM_SEED, "=" );
+    random_seed.add_cla_id( "--", random_seed_str, "=" );
     store.add( random_seed );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::output_format> report_format( REPORT_FORMAT, (
+    rt::enum_parameter<unit_test::output_format> report_format( report_format_str, (
         rt::description = "Specifies report format.",
         rt::env_var = "BOOST_TEST_REPORT_FORMAT",
         rt::default_value = OF_CLF,
@@ -448,7 +448,7 @@ register_parameters( rt::parameters_store& store )
             ( "XML", OF_XML )
         ,
 #endif
-        rt::help = "Parameter " + REPORT_FORMAT + " allows to set the framework's report format "
+        rt::help = "Parameter " + report_format_str + " allows to set the framework's report format "
                    "to one of the formats supplied by the framework. The only acceptable values "
                    "for this parameter are the names of the output formats. By default the framework "
                    "uses human readable format (HRF) for results reporting. Alternatively you can "
@@ -456,13 +456,13 @@ register_parameters( rt::parameters_store& store )
                    "automation tools."
     ));
 
-    report_format.add_cla_id( "--", REPORT_FORMAT, "=" );
+    report_format.add_cla_id( "--", report_format_str, "=" );
     report_format.add_cla_id( "-", "m", " " );
     store.add( report_format );
 
     ///////////////////////////////////////////////
 
-    rt::enum_parameter<unit_test::report_level> report_level( REPORT_LEVEL, (
+    rt::enum_parameter<unit_test::report_level> report_level( report_level_str, (
         rt::description = "Specifies report level.",
         rt::env_var = "BOOST_TEST_REPORT_LEVEL",
         rt::default_value = CONFIRMATION_REPORT,
@@ -482,155 +482,155 @@ register_parameters( rt::parameters_store& store )
             ( "no",       NO_REPORT )
         ,
 #endif
-        rt::help = "Parameter " + REPORT_LEVEL + " allows to set the verbosity level of the "
+        rt::help = "Parameter " + report_level_str + " allows to set the verbosity level of the "
                    "testing result report generated by the framework. Use value 'no' to "
                    "eliminate the results report completely."
     ));
 
-    report_level.add_cla_id( "--", REPORT_LEVEL, "=" );
+    report_level.add_cla_id( "--", report_level_str, "=" );
     report_level.add_cla_id( "-", "r", " " );
     store.add( report_level );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string> report_mem_leaks( REPORT_MEM_LEAKS, (
+    rt::parameter<std::string> report_mem_leaks( report_mem_leaks_str, (
         rt::description = "File where to report memory leaks to.",
         rt::env_var = "BOOST_TEST_REPORT_MEMORY_LEAKS_TO",
         rt::default_value = std::string(),
         rt::value_hint = "<file name>",
-        rt::help = "Parameter " + REPORT_MEM_LEAKS + " allows to specify a file where to report "
+        rt::help = "Parameter " + report_mem_leaks_str + " allows to specify a file where to report "
                    "memory leaks to. The parameter does not have default value. If it is not specified, "
                    "memory leaks (if any) are reported to the standard error stream."
     ));
 
-    report_mem_leaks.add_cla_id( "--", REPORT_MEM_LEAKS, "=" );
+    report_mem_leaks.add_cla_id( "--", report_mem_leaks_str, "=" );
     store.add( report_mem_leaks );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string> report_sink( REPORT_SINK, (
+    rt::parameter<std::string> report_sink( report_sink_str, (
         rt::description = "Specifies report sink: stderr(default), stdout or file name.",
         rt::env_var = "BOOST_TEST_REPORT_SINK",
         rt::value_hint = "<stderr|stdout|file name>",
-        rt::help = "Parameter " + REPORT_SINK + " allows to set the result report sink - "
+        rt::help = "Parameter " + report_sink_str + " allows to set the result report sink - "
                    "the location where the framework writes the result report to, thus it "
                    "allows to easily redirect the result report to a file or a standard "
                    "stream. By default the testing result report is directed to the "
                    "standard error stream."
     ));
 
-    report_sink.add_cla_id( "--", REPORT_SINK, "=" );
+    report_sink.add_cla_id( "--", report_sink_str, "=" );
     report_sink.add_cla_id( "-", "e", " " );
     store.add( report_sink );
 
     ///////////////////////////////////////////////
 
-    rt::option result_code( RESULT_CODE, (
+    rt::option result_code( result_code_str, (
         rt::description = "Disables test modules's result code generation.",
         rt::env_var = "BOOST_TEST_RESULT_CODE",
         rt::default_value = true,
-        rt::help = "The 'no' argument value for the parameter " + RESULT_CODE + " instructs the "
+        rt::help = "The 'no' argument value for the parameter " + result_code_str + " instructs the "
                    "framework to always return zero result code. This can be used for test programs "
                    "executed within IDE. By default this parameter has value 'yes'."
     ));
 
-    result_code.add_cla_id( "--", RESULT_CODE, "=", true );
+    result_code.add_cla_id( "--", result_code_str, "=", true );
     result_code.add_cla_id( "-", "c", " " );
     store.add( result_code );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string,rt::REPEATABLE_PARAM> tests_to_run( RUN_FILTERS, (
+    rt::parameter<std::string,rt::REPEATABLE_PARAM> tests_to_run( run_filters_str, (
         rt::description = "Filters, which test units to include or exclude from test module execution.",
         rt::env_var = "BOOST_TEST_RUN_FILTERS",
         rt::value_hint = "<test unit filter>",
-        rt::help = "Parameter " + RUN_FILTERS + " allows to filter which test units to execute during "
+        rt::help = "Parameter " + run_filters_str + " allows to filter which test units to execute during "
                    "testing. The framework supports both 'selection filters', which allow to select "
                    "which test units to enable from the set of available test units, and 'disabler "
                    "filters', which allow to disable some test units. The __UTF__ also supports "
                    "enabling/disabling test units at compile time. These settings identify the default "
-                   "set of test units to run. Parameter " + RUN_FILTERS + " is used to change this default. "
+                   "set of test units to run. Parameter " + run_filters_str + " is used to change this default. "
                    "This parameter is repeatable, so you can specify more than one filter if necessary."
     ));
 
-    tests_to_run.add_cla_id( "--", RUN_FILTERS, "=" );
+    tests_to_run.add_cla_id( "--", run_filters_str, "=" );
     tests_to_run.add_cla_id( "-", "t", " " );
     store.add( tests_to_run );
 
     ///////////////////////////////////////////////
 
-    rt::option save_test_pattern( SAVE_TEST_PATTERN, (
+    rt::option save_test_pattern( save_test_pattern_str, (
         rt::description = "Allows to switch between saving or matching test pattern file.",
         rt::env_var = "BOOST_TEST_SAVE_PATTERN",
-        rt::help = "Parameter " + SAVE_TEST_PATTERN + " facilitates switching mode of operation for "
+        rt::help = "Parameter " + save_test_pattern_str + " facilitates switching mode of operation for "
                    "testing output streams.\n\nThis parameter serves no particular purpose within the "
                    "framework itself. It can be used by test modules relying on output_test_stream to "
                    "implement testing logic. Default mode is 'match' (false)."
     ));
 
-    save_test_pattern.add_cla_id( "--", SAVE_TEST_PATTERN, "=" );
+    save_test_pattern.add_cla_id( "--", save_test_pattern_str, "=" );
     store.add( save_test_pattern );
 
     ///////////////////////////////////////////////
 
-    rt::option show_progress( SHOW_PROGRESS, (
+    rt::option show_progress( show_progress_str, (
         rt::description = "Turns on progress display.",
         rt::env_var = "BOOST_TEST_SHOW_PROGRESS",
-        rt::help = "Parameter " + SHOW_PROGRESS + " instructs the framework to display test progress "
+        rt::help = "Parameter " + show_progress_str + " instructs the framework to display test progress "
                    "information. By default the test progress is not shown."
     ));
 
-    show_progress.add_cla_id( "--", SHOW_PROGRESS, "=" );
+    show_progress.add_cla_id( "--", show_progress_str, "=" );
     show_progress.add_cla_id( "-", "p", " " );
     store.add( show_progress );
 
     ///////////////////////////////////////////////
 
-    rt::option use_alt_stack( USE_ALT_STACK, (
+    rt::option use_alt_stack( use_alt_stack_str, (
         rt::description = "Turns on/off usage of an alternative stack for signal handling.",
         rt::env_var = "BOOST_TEST_USE_ALT_STACK",
         rt::default_value = true,
-        rt::help = "Parameter " + USE_ALT_STACK + " instructs the framework to use alternative "
+        rt::help = "Parameter " + use_alt_stack_str + " instructs the framework to use alternative "
                    "stack for signals processing, on platforms where they are supported. The feature "
                    "is enabled by default, but can be disabled using this parameter."
     ));
 
-    use_alt_stack.add_cla_id( "--", USE_ALT_STACK, "=", true );
+    use_alt_stack.add_cla_id( "--", use_alt_stack_str, "=", true );
     store.add( use_alt_stack );
 
     ///////////////////////////////////////////////
 
-    rt::option wait_for_debugger( WAIT_FOR_DEBUGGER, (
+    rt::option wait_for_debugger( wait_for_debugger_str, (
         rt::description = "Forces test module to wait for button to be pressed before starting test run.",
         rt::env_var = "BOOST_TEST_WAIT_FOR_DEBUGGER",
-        rt::help = "Parameter " + WAIT_FOR_DEBUGGER + " instructs the framework to pause before starting "
+        rt::help = "Parameter " + wait_for_debugger_str + " instructs the framework to pause before starting "
                    "test units execution, so that you can attach a debugger to running test module. By "
                    "default this parameters turned off."
     ));
 
-    wait_for_debugger.add_cla_id( "--", WAIT_FOR_DEBUGGER, "=" );
+    wait_for_debugger.add_cla_id( "--", wait_for_debugger_str, "=" );
     wait_for_debugger.add_cla_id( "-", "w", " " );
     store.add( wait_for_debugger );
 
     ///////////////////////////////////////////////
 
-    rt::parameter<std::string> help( HELP, (
+    rt::parameter<std::string> help( help_str, (
         rt::description = "Help for framework parameters.",
         rt::optional_value = std::string(),
         rt::value_hint = "<parameter name>",
-        rt::help = "Parameter " + HELP + " displays help on the framework's parameters. "
+        rt::help = "Parameter " + help_str + " displays help on the framework's parameters. "
                    "The parameter accepts an optional argument value. If present, an argument value is "
                    "interpreted as a parameter name (name guessing works as well, so for example "
                    "--help=rand displays help on the parameter random). If the parameter name is unknown "
                    "or ambiguous error is reported. If argument value is absent, a summary of all "
                    "framework's parameter is displayed."
     ));
-    help.add_cla_id( "--", HELP, "=" );
+    help.add_cla_id( "--", help_str, "=" );
     store.add( help );
 
     ///////////////////////////////////////////////
 
-    rt::option usage( USAGE, (
+    rt::option usage( usage_str, (
         rt::description = "Short message explaining usage of Boost.Test parameters."
     ));
     usage.add_cla_id( "-", "?", " " );
@@ -638,10 +638,10 @@ register_parameters( rt::parameters_store& store )
 
     ///////////////////////////////////////////////
 
-    rt::option version( VERSION, (
+    rt::option version( version_str, (
         rt::description = "Prints Boost.Test version and exits."
     ));
-    version.add_cla_id( "--", VERSION, " " );
+    version.add_cla_id( "--", version_str, " " );
     store.add( version );
 }
 
@@ -676,24 +676,24 @@ init( int& argc, char** argv )
         rt::finalize_arguments( s_parameters_store, s_arguments_store );
 
         // Report help if requested
-        if( runtime_config::get<bool>( VERSION ) ) {
+        if( runtime_config::get<bool>( version_str ) ) {
             parser->version( std::cerr );
             BOOST_TEST_I_THROW( framework::nothing_to_test( boost::exit_success ) );
         }
-        else if( runtime_config::get<bool>( USAGE ) ) {
+        else if( runtime_config::get<bool>( usage_str ) ) {
             parser->usage( std::cerr );
             BOOST_TEST_I_THROW( framework::nothing_to_test( boost::exit_success ) );
         }
-        else if( s_arguments_store.has( HELP ) ) {
-            parser->help( std::cerr, s_parameters_store, runtime_config::get<std::string>( HELP ) );
+        else if( s_arguments_store.has( help_str ) ) {
+            parser->help( std::cerr, s_parameters_store, runtime_config::get<std::string>( help_str ) );
             BOOST_TEST_I_THROW( framework::nothing_to_test( boost::exit_success ) );
         }
 
         // A bit of business logic: output_format takes precedence over log/report formats
-        if( s_arguments_store.has( OUTPUT_FORMAT ) ) {
-            unit_test::output_format of = s_arguments_store.get<unit_test::output_format>( OUTPUT_FORMAT );
-            s_arguments_store.set( REPORT_FORMAT, of );
-            s_arguments_store.set( LOG_FORMAT, of );
+        if( s_arguments_store.has( output_format_str ) ) {
+            unit_test::output_format of = s_arguments_store.get<unit_test::output_format>( output_format_str );
+            s_arguments_store.set( report_format_str, of );
+            s_arguments_store.set( log_format_str, of );
         }
 
     }
@@ -747,7 +747,7 @@ argument_store()
 bool
 save_pattern()
 {
-    return runtime_config::get<bool>( SAVE_TEST_PATTERN );
+    return runtime_config::get<bool>( save_test_pattern_str );
 }
 
 //____________________________________________________________________________//

--- a/test/execution_monitor-ts/errors-handling-test.cpp
+++ b/test/execution_monitor-ts/errors-handling-test.cpp
@@ -185,9 +185,9 @@ BOOST_AUTO_TEST_CASE( test_errors_handling )
             framework::run( test );
 
             unit_test_log.set_stream( std::cout );
-            unit_test_log.set_format( runtime_config::get<output_format>( runtime_config::LOG_FORMAT ) );
+            unit_test_log.set_format( runtime_config::get<output_format>( runtime_config::log_format_str ) );
 
-            log_level ll = runtime_config::get<log_level>( runtime_config::LOG_LEVEL );
+            log_level ll = runtime_config::get<log_level>( runtime_config::log_level_str );
             unit_test_log.set_threshold_level( ll != invalid_log_level? ll : log_all_errors );
 
             BOOST_CHECK( test_output.match_pattern() );

--- a/test/framework-ts/log-formatter-test.cpp
+++ b/test/framework-ts/log-formatter-test.cpp
@@ -117,7 +117,7 @@ void check( output_test_stream& output, test_suite* ts )
 struct guard {
     ~guard()
     {
-        boost::unit_test::unit_test_log.set_format( runtime_config::get<output_format>( runtime_config::LOG_FORMAT ) );
+        boost::unit_test::unit_test_log.set_format( runtime_config::get<output_format>( runtime_config::log_format_str ) );
         boost::unit_test::unit_test_log.set_stream( std::cout );
     }
 };

--- a/test/framework-ts/result-report-test.cpp
+++ b/test/framework-ts/result-report-test.cpp
@@ -101,7 +101,7 @@ struct guard {
     {
         results_reporter::set_stream( std::cerr );
         results_reporter::set_format( runtime_config::get<output_format>(
-            runtime_config::REPORT_FORMAT ) );
+            runtime_config::report_format_str ) );
     }
 };
 

--- a/test/test-organization-ts/test_unit-order-shuffled-test.cpp
+++ b/test/test-organization-ts/test_unit-order-shuffled-test.cpp
@@ -109,7 +109,7 @@ struct test_tree {
 BOOST_FIXTURE_TEST_CASE( test_no_seed, test_tree )
 {
     // no seed set
-    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::RANDOM_SEED, 0);
+    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::random_seed_str, 0);
 
     tu_order_collector res1 = run_tree( master );
     tu_order_collector res2 = run_tree( master );
@@ -120,7 +120,7 @@ BOOST_FIXTURE_TEST_CASE( test_no_seed, test_tree )
 BOOST_FIXTURE_TEST_CASE( test_seed_to_time, test_tree )
 {
     // seed = 1 means current time is used.
-    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::RANDOM_SEED, 1);
+    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::random_seed_str, 1);
 
     tu_order_collector res1 = run_tree( master );
     tu_order_collector res2 = run_tree( master );
@@ -132,16 +132,16 @@ BOOST_FIXTURE_TEST_CASE( test_seed_identical, test_tree )
 {
     // seed = 1 means current time is used.
     unsigned int seed = static_cast<unsigned int>( std::time( 0 ) );
-    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::RANDOM_SEED, seed);
+    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::random_seed_str, seed);
     tu_order_collector res1 = run_tree( master );
 
-    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::RANDOM_SEED, seed);
+    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::random_seed_str, seed);
     tu_order_collector res2 = run_tree( master );
 
     BOOST_TEST( res1.m_order == res2.m_order, tt::per_element() );
 
     // using time seed now
-    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::RANDOM_SEED, 1);
+    ut::runtime_config::s_arguments_store.set<unsigned int>(ut::runtime_config::random_seed_str, 1);
     tu_order_collector res3 = run_tree( master );
     BOOST_TEST( res1.m_order != res3.m_order ); // some elements might be the same, but not the full sequences
 

--- a/test/writing-test-ts/test_tools-test.cpp
+++ b/test/writing-test-ts/test_tools-test.cpp
@@ -129,9 +129,9 @@ BOOST_AUTO_TEST_CASE( name )                                        \
     ut::framework::run( impl );                                     \
                                                                     \
     ut::log_level ll = ut::runtime_config::get<ut::log_level>(      \
-        ut::runtime_config::LOG_LEVEL );                            \
+        ut::runtime_config::log_level_str );                            \
     ut::output_format lf = ut::runtime_config::get<ut::output_format>( \
-        ut::runtime_config::LOG_FORMAT );                           \
+        ut::runtime_config::log_format_str );                           \
                                                                     \
     ut::unit_test_log.set_threshold_level(                          \
         ll != ut::invalid_log_level ? ll : ut::log_all_errors );    \


### PR DESCRIPTION
Capitals clash by convention with #define, and in this case
VERSION clashes with GNU Autotools. This means projecting using
GNU Autotools and Boost::Test library no longer compile.

To fix this problem and possibly others down the line,
downcase all the string constants in the rt::runtime_config
namespace. (trac 12748)