### PR TITLE
Fix Markdown link format

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,7 +1,7 @@
 This folder contains the documentation for the Boost.Test library.
 Any contribution or submission to the library should be accompanied by the corresponding documentation.
 
-The format of the documentation uses [http://www.boost.org/tools/quickbook/index.html Quickbook].
+The format of the documentation uses [http://www.boost.org/tools/quickbook/index.html](Quickbook).
 
 How to build the documentation
 ==============================


### PR DESCRIPTION
A simple fix of the Markdown syntax for the link in the doc/README.md file.