### PR TITLE
Deliberate-failure tests shouldn't be optimized

### DIFF
--- a/doc/examples/example22.run-fail.cpp
+++ b/doc/examples/example22.run-fail.cpp
@@ -23,8 +23,8 @@ void goo( int )
 {
 }
 
-#if defined(BOOST_MSVC)
-// compiler optimizations may cause this code NOT to crash.
+#if defined(BOOST_MSVC) && (BOOST_MSVC > 1900)
+// VS2017+ compiler optimizations may cause this code NOT to crash.
 #pragma optimize("", off)
 #endif
 
@@ -33,7 +33,7 @@ void foo( int i )
     goo( 2/(i-1) );
 }
 
-#if defined(BOOST_MSVC)
+#if defined(BOOST_MSVC) && (BOOST_MSVC > 1900)
 #pragma optimize("", on)
 #endif
 //]

--- a/doc/examples/example22.run-fail.cpp
+++ b/doc/examples/example22.run-fail.cpp
@@ -23,8 +23,17 @@ void goo( int )
 {
 }
 
+#if defined(BOOST_MSVC)
+// compiler optimizations may cause this code NOT to crash.
+#pragma optimize("", off)
+#endif
+
 void foo( int i )
 {
     goo( 2/(i-1) );
 }
+
+#if defined(BOOST_MSVC)
+#pragma optimize("", on)
+#endif
 //]

--- a/doc/examples/example23.run-fail.cpp
+++ b/doc/examples/example23.run-fail.cpp
@@ -9,15 +9,15 @@
 #define BOOST_TEST_MODULE example
 #include <boost/test/included/unit_test.hpp>
 
-#if defined(BOOST_MSVC)
-// compiler optimizations may cause this code NOT to crash.
+#if defined(BOOST_MSVC) && (BOOST_MSVC > 1900)
+// VS2017+ compiler optimizations may cause this code NOT to crash.
 #pragma optimize("", off)
 #endif
 
 
 void foo( int ) {}
 
-#if defined(BOOST_MSVC)
+#if defined(BOOST_MSVC) && (BOOST_MSVC > 1900)
 #pragma optimize("", on)
 #endif
 

--- a/doc/examples/example23.run-fail.cpp
+++ b/doc/examples/example23.run-fail.cpp
@@ -9,7 +9,17 @@
 #define BOOST_TEST_MODULE example
 #include <boost/test/included/unit_test.hpp>
 
+#if defined(BOOST_MSVC)
+// compiler optimizations may cause this code NOT to crash.
+#pragma optimize("", off)
+#endif
+
+
 void foo( int ) {}
+
+#if defined(BOOST_MSVC)
+#pragma optimize("", on)
+#endif
 
 BOOST_AUTO_TEST_CASE( test_case )
 {


### PR DESCRIPTION
A few tests designed to deliberately fail appeal to UB (undefined
behavior), but as the MSVC optimizer improves we will take advantage of
that to remove UB statements. In order for deliberate failures to occur,
the tests must have the optimizer turned off.