### PR TITLE
[WIP] Describe operator constraints for bitwise comparison

### DIFF
--- a/doc/testing_tools/boost_test_bitwise_comparison.qbk
+++ b/doc/testing_tools/boost_test_bitwise_comparison.qbk
@@ -13,6 +13,8 @@
 The manipulator [classref boost::test_tools::bitwise] can be provided to the __BOOST_TEST__ macro in order to have a bitwise comparison
 of the operands. In that case, the __UTF__ indicates the bit indices where the two operands do not match. 
 
+Operands of bitwise comparison need to support bitwise left shift (`T operator<<(T, std::size_t)`).
+
 [bt_example boost_test_bitwise..BOOST_TEST bitwise comparison..run-fail]
 
 [note the indices start at least significant bit.]


### PR DESCRIPTION
I've recently been surprised that bitwise comparison only works for integer types, not for arbitrary types. I would have expected it reinterprets whatever value it gets as an array of bytes and compares these bit by bit.
A short discussion on the [Boost Users Mailinglist](http://lists.boost.org/boost-users/2017/02/87165.php) indicated the restriction to integer types only might be intentional and I see some reasons for that. Nevertheless I'd prefer these constraints to be documented prominently.
This PR therefore proposes a possible update to the documentation and is mainly created to start a discussion, not to be merged right away.