### PR TITLE
Silence unreachable code warning in MSVC (/W4)

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1287,7 +1287,7 @@ execution_monitor::execute( boost::function<int ()> const& F )
 
 #endif // !BOOST_NO_EXCEPTIONS
 
-    return 0;  // never reached; supplied to quiet compiler warnings
+    BOOST_UNREACHABLE_RETURN(0);  // never reached; supplied to quiet compiler warnings
 } // execute
 
 //____________________________________________________________________________//

--- a/include/boost/test/utils/named_params.hpp
+++ b/include/boost/test/utils/named_params.hpp
@@ -131,23 +131,23 @@ struct nil {
 #else
     operator T const&() const
 #endif
-    { nfp_detail::report_access_to_invalid_parameter(true); static T* v = 0; return *v; }
+    { nfp_detail::report_access_to_invalid_parameter(true); static T* v = 0; BOOST_UNREACHABLE_RETURN(*v); }
 
     template<typename T>
     T any_cast() const
-    { nfp_detail::report_access_to_invalid_parameter(true); static typename remove_reference<T>::type* v = 0; return *v; }
+    { nfp_detail::report_access_to_invalid_parameter(true); static typename remove_reference<T>::type* v = 0; BOOST_UNREACHABLE_RETURN(*v); }
 
     template<typename Arg1>
     nil operator()( Arg1 const& )
-    { nfp_detail::report_access_to_invalid_parameter(true); return nil(); }
+    { nfp_detail::report_access_to_invalid_parameter(true); BOOST_UNREACHABLE_RETURN(nil()); }
 
     template<typename Arg1,typename Arg2>
     nil operator()( Arg1 const&, Arg2 const& )
-    { nfp_detail::report_access_to_invalid_parameter(true); return nil(); }
+    { nfp_detail::report_access_to_invalid_parameter(true); BOOST_UNREACHABLE_RETURN(nil()); }
 
     template<typename Arg1,typename Arg2,typename Arg3>
     nil operator()( Arg1 const&, Arg2 const&, Arg3 const& )
-    { nfp_detail::report_access_to_invalid_parameter(true); return nil(); }
+    { nfp_detail::report_access_to_invalid_parameter(true); BOOST_UNREACHABLE_RETURN(nil()); }
 
     // Visitation support
     template<typename Visitor>


### PR DESCRIPTION
Disable level 4 warning C4702 on MSVC. Since the comments indicate, that the unreachable `return 0` silences some other compiler warning I think it is best to simply ignore the MSVC warning.