### PR TITLE
WIP: use std::function if c++11 <functional> is available

### DIFF
--- a/doc/examples/example08.run-fail.cpp
+++ b/doc/examples/example08.run-fail.cpp
@@ -27,7 +27,11 @@ bool init_unit_test()
 {
   double params[] = { 1., 1.1, 1.01, 1.001, 1.0001 };
 
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
   boost::function<void (double)> test_method = bind( &test_class::test_method, &tester, _1);
+#else
+  std::function<void (double)> test_method = bind( &test_class::test_method, &tester, _1);
+#endif
 
   framework::master_test_suite().
     add( BOOST_PARAM_TEST_CASE( test_method, params, params+5 ) );

--- a/include/boost/test/debug.hpp
+++ b/include/boost/test/debug.hpp
@@ -18,8 +18,12 @@
 #include <boost/test/detail/config.hpp>
 #include <boost/test/utils/basic_cstring/basic_cstring.hpp>
 
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 // Boost
 #include <boost/function/function1.hpp>
+#else
+#include <functional>
+#endif
 
 // STL
 #include <string>
@@ -72,8 +76,11 @@ struct dbg_startup_info {
 };
 
 /// Signature of debugger starter routine. Takes an instance of dbg_startup_into as only argument
-typedef boost::function<void (dbg_startup_info const&)> dbg_starter;
-
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef boost::function<void (dbg_startup_info const&)> dbg_starter;
+#else
+    using dbg_starter = std::function<void (dbg_startup_info const&)>;
+#endif
 // ************************************************************************** //
 /// Specifies which debugger to use when attaching and optionally what routine to use to start that debugger
 

--- a/include/boost/test/execution_monitor.hpp
+++ b/include/boost/test/execution_monitor.hpp
@@ -25,7 +25,11 @@
 #include <boost/scoped_array.hpp>
 #include <boost/type.hpp>
 #include <boost/cstdlib.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function0.hpp>
+#else
+#include <functional>
+#endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
 
@@ -96,6 +100,14 @@
 //____________________________________________________________________________//
 
 namespace boost {
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef boost::function<void ()> test_func_t;
+    typedef boost::function<int ()> result_func_t;
+#else
+    using test_func_t = std::function<void ()>;
+    using result_func_t = std::function<int ()>;
+#endif
 
 /// @defgroup ExecutionMonitor Function Execution Monitor
 /// @{
@@ -196,8 +208,7 @@ public:
 
     // translator holder interface
     // invokes the function F inside the try/catch guarding against specific exception
-    virtual int operator()( boost::function<int ()> const& F ) = 0;
-
+    virtual int operator()( result_func_t const& F ) = 0;
     // erases specific translator holder from the chain
     translator_holder_base_ptr erase( translator_holder_base_ptr this_, const_string tag )
     {
@@ -366,14 +377,14 @@ public:
     /// @param[in] F  Function to monitor
     /// @returns  value returned by function call F().
     /// @see vexecute
-    int         execute( boost::function<int ()> const& F );
+    int         execute( result_func_t const& F );
 
     /// @brief Execution monitor entry point for functions returning void
     ///
     /// This method is semantically identical to execution_monitor::execute, but des't produce any result code.
     /// @param[in] F  Function to monitor
     /// @see execute
-    void         vexecute( boost::function<void ()> const& F );
+    void         vexecute( test_func_t const& F );
     // @}
 
     // @name Exception translator registration
@@ -419,8 +430,7 @@ public:
 
 private:
     // implementation helpers
-    int         catch_signals( boost::function<int ()> const& F );
-
+    int         catch_signals( result_func_t const& F );
     // Data members
     detail::translator_holder_base_ptr  m_custom_translators;
     boost::scoped_array<char>           m_alt_stack;
@@ -440,7 +450,7 @@ public:
     : translator_holder_base( next, tag ), m_translator( tr ) {}
 
     // translator holder interface
-    virtual int operator()( boost::function<int ()> const& F )
+    virtual int operator()( result_func_t const& F )
     {
         BOOST_TEST_I_TRY {
             return m_next ? (*m_next)( F ) : F();

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -839,7 +839,7 @@ static void boost_execution_monitor_attaching_signal_handler( int sig, siginfo_t
 // ************************************************************************** //
 
 int
-execution_monitor::catch_signals( boost::function<int ()> const& F )
+execution_monitor::catch_signals( result_func_t const& F )
 {
     using namespace detail;
 
@@ -1191,7 +1191,7 @@ execution_monitor::execution_monitor()
 //____________________________________________________________________________//
 
 int
-execution_monitor::execute( boost::function<int ()> const& F )
+execution_monitor::execute( result_func_t const& F )
 {
     if( debug::under_debugger() )
         p_catch_system_errors.value = false;
@@ -1295,16 +1295,15 @@ execution_monitor::execute( boost::function<int ()> const& F )
 namespace detail {
 
 struct forward {
-    explicit    forward( boost::function<void ()> const& F ) : m_F( F ) {}
-
+    explicit    forward( test_func_t const& F ) : m_F( F ) {}
     int         operator()() { m_F(); return 0; }
 
-    boost::function<void ()> const& m_F;
+    test_func_t const& m_F;
 };
 
 } // namespace detail
 void
-execution_monitor::vexecute( boost::function<void ()> const& F )
+execution_monitor::vexecute( test_func_t const& F )
 {
     execute( detail::forward( F ) );
 }

--- a/include/boost/test/impl/test_tree.ipp
+++ b/include/boost/test/impl/test_tree.ipp
@@ -198,7 +198,7 @@ test_unit::has_label( const_string l ) const
 // **************                   test_case                  ************** //
 // ************************************************************************** //
 
-test_case::test_case( const_string name, boost::function<void ()> const& test_func )
+test_case::test_case( const_string name, test_func_t const& test_func )
 : test_unit( name, "", 0, static_cast<test_unit_type>(type) )
 , p_test_func( test_func )
 {
@@ -207,7 +207,7 @@ test_case::test_case( const_string name, boost::function<void ()> const& test_fu
 
 //____________________________________________________________________________//
 
-test_case::test_case( const_string name, const_string file_name, std::size_t line_num, boost::function<void ()> const& test_func )
+    test_case::test_case( const_string name, const_string file_name, std::size_t line_num, test_func_t const& test_func )
 : test_unit( name, file_name, line_num, static_cast<test_unit_type>(type) )
 , p_test_func( test_func )
 {

--- a/include/boost/test/impl/unit_test_monitor.ipp
+++ b/include/boost/test/impl/unit_test_monitor.ipp
@@ -34,7 +34,7 @@ namespace unit_test {
 // ************************************************************************** //
 
 unit_test_monitor_t::error_level
-unit_test_monitor_t::execute_and_translate( boost::function<void ()> const& func, unsigned timeout )
+unit_test_monitor_t::execute_and_translate( test_func_t const& func, unsigned timeout )
 {
     BOOST_TEST_I_TRY {
         p_catch_system_errors.value     = runtime_config::get<bool>( runtime_config::btrt_catch_sys_errors );

--- a/include/boost/test/parameterized_test.hpp
+++ b/include/boost/test/parameterized_test.hpp
@@ -20,9 +20,14 @@
 #include <boost/type_traits/remove_const.hpp>
 
 #include <boost/bind.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function1.hpp>
+#else
+#include <functional>
+#endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
+
 
 //____________________________________________________________________________//
 
@@ -53,7 +58,13 @@ namespace ut_detail {
 template<typename ParamType, typename ParamIter>
 class param_test_case_generator : public test_unit_generator {
 public:
-    param_test_case_generator( boost::function<void (ParamType)> const& test_func,
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef boost::function<void (ParamType)> param_func_t;
+#else
+    using param_func_t = std::function<void (ParamType)>;
+#endif
+
+    param_test_case_generator( param_func_t const&                      test_func,
                                const_string                             tc_name,
                                const_string                             tc_file,
                                std::size_t                              tc_line,
@@ -81,7 +92,7 @@ public:
 
 private:
     // Data members
-    boost::function<void (ParamType)>    m_test_func;
+    param_func_t            m_test_func;
     std::string             m_tc_name;
     const_string            m_tc_file;
     std::size_t             m_tc_line;
@@ -93,8 +104,11 @@ private:
 
 template<typename UserTestCase,typename ParamType>
 struct user_param_tc_method_invoker {
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
     typedef void (UserTestCase::*test_method)( ParamType );
-
+#else
+    using test_method = std::function<void (ParamType)>;
+#endif
     // Constructor
     user_param_tc_method_invoker( shared_ptr<UserTestCase> inst, test_method test_method )
     : m_inst( inst ), m_test_method( test_method ) {}
@@ -112,7 +126,11 @@ struct user_param_tc_method_invoker {
 
 template<typename ParamType, typename ParamIter>
 inline ut_detail::param_test_case_generator<ParamType,ParamIter>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 make_test_case( boost::function<void (ParamType)> const& test_func,
+#else
+make_test_case( std::function<void (ParamType)> const& test_func,
+#endif
                 const_string                             tc_name,
                 const_string                             tc_file,
                 std::size_t                              tc_line,
@@ -169,4 +187,3 @@ make_test_case( void (UserTestCase::*test_method )( ParamType ),
 #include <boost/test/detail/enable_warnings.hpp>
 
 #endif // BOOST_TEST_PARAMETERIZED_TEST_HPP_021102GER
-

--- a/include/boost/test/tree/decorator.hpp
+++ b/include/boost/test/tree/decorator.hpp
@@ -28,8 +28,12 @@
 
 // Boost
 #include <boost/shared_ptr.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function0.hpp>
 #include <boost/function/function1.hpp>
+#else
+#include <functional>
+#endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
 
@@ -230,7 +234,7 @@ fixture( Arg const& arg )
 //____________________________________________________________________________//
 
 inline fixture_t
-fixture( boost::function<void()> const& setup, boost::function<void()> const& teardown = boost::function<void()>() )
+fixture( fixture_func_t const& setup, fixture_func_t const& teardown = fixture_func_t() )
 {
     return fixture_t( test_unit_fixture_ptr( new unit_test::function_based_fixture( setup, teardown ) ) );
 }
@@ -243,8 +247,11 @@ fixture( boost::function<void()> const& setup, boost::function<void()> const& te
 
 class BOOST_TEST_DECL precondition : public decorator::base {
 public:
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
     typedef boost::function<test_tools::assertion_result (test_unit_id)>   predicate_t;
-
+#else
+    using predicate_t = std::function<test_tools::assertion_result (test_unit_id)>;
+#endif
     explicit                precondition( predicate_t p ) : m_precondition( p ) {}
 
 private:

--- a/include/boost/test/tree/fixture.hpp
+++ b/include/boost/test/tree/fixture.hpp
@@ -21,7 +21,12 @@
 // Boost
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function0.hpp>
+#else
+#include <functional>
+#endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
 
@@ -29,6 +34,12 @@
 
 namespace boost {
 namespace unit_test {
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef boost::function<void ()> fixture_func_t;
+#else
+    using fixture_func_t = std::function<void ()>;
+#endif
 
 // ************************************************************************** //
 // **************               test_unit_fixture              ************** //
@@ -91,7 +102,7 @@ private:
 class function_based_fixture : public test_unit_fixture {
 public:
     // Constructor
-    function_based_fixture( boost::function<void ()> const& setup_, boost::function<void ()> const& teardown_ )
+    function_based_fixture( fixture_func_t const& setup_, fixture_func_t const& teardown_ )
     : m_setup( setup_ )
     , m_teardown( teardown_ )
     {
@@ -103,8 +114,8 @@ private:
     virtual void                teardown()  { if( m_teardown ) m_teardown(); }
 
     // Data members
-    boost::function<void ()>    m_setup;
-    boost::function<void ()>    m_teardown;
+    fixture_func_t              m_setup;
+    fixture_func_t              m_teardown;
 };
 
 } // namespace unit_test

--- a/include/boost/test/tree/test_case_template.hpp
+++ b/include/boost/test/tree/test_case_template.hpp
@@ -29,7 +29,11 @@
 #include <boost/mpl/identity.hpp>
 #include <boost/type.hpp>
 #include <boost/type_traits/is_const.hpp>
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function0.hpp>
+#else
+#include <functional>
+#endif
 
 #if defined(BOOST_NO_TYPEID) || defined(BOOST_NO_RTTI)
 #  include <boost/current_function.hpp>

--- a/include/boost/test/tree/test_unit.hpp
+++ b/include/boost/test/tree/test_unit.hpp
@@ -26,9 +26,12 @@
 #include <boost/test/utils/class_properties.hpp>
 
 // Boost
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 #include <boost/function/function0.hpp>
 #include <boost/function/function1.hpp>
-
+#else
+#include <functional>
+#endif
 // STL
 #include <vector>
 #include <string>
@@ -51,6 +54,12 @@ class state;
 
 typedef std::vector<test_unit_id> test_unit_id_list;
 
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef boost::function<void ()> test_func_t;
+#else
+    using test_func_t = std::function<void ()>;
+#endif
+
 class BOOST_TEST_DECL test_unit {
 public:
     enum { type = TUT_ANY };
@@ -64,7 +73,11 @@ public:
     typedef std::vector<decorator::base_ptr>                                decor_list_t;
     typedef BOOST_READONLY_PROPERTY(std::vector<std::string>,(test_unit))   label_list_t;
 
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
     typedef boost::function<test_tools::assertion_result (test_unit_id)>    precondition_t;
+#else
+    using precondition_t = std::function<test_tools::assertion_result (test_unit_id)>;
+#endif
     typedef BOOST_READONLY_PROPERTY(std::vector<precondition_t>,(test_unit)) precond_list_t;
 
     // preconditions management
@@ -138,11 +151,11 @@ public:
     enum { type = TUT_CASE };
 
     // Constructor
-    test_case( const_string tc_name, boost::function<void ()> const& test_func );
-    test_case( const_string tc_name, const_string tc_file, std::size_t tc_line, boost::function<void ()> const& test_func );
+    test_case( const_string tc_name, test_func_t const& test_func );
+    test_case( const_string tc_name, const_string tc_file, std::size_t tc_line, test_func_t const& test_func );
 
     // Public property
-    typedef BOOST_READONLY_PROPERTY(boost::function<void ()>,(test_case))  test_func;
+    typedef BOOST_READONLY_PROPERTY(test_func_t,(test_case))  test_func;
 
     test_func   p_test_func;
 
@@ -244,7 +257,7 @@ struct user_tc_method_invoker {
 // ************************************************************************** //
 
 inline test_case*
-make_test_case( boost::function<void ()> const& test_func, const_string tc_name, const_string tc_file, std::size_t tc_line )
+make_test_case( test_func_t const& test_func, const_string tc_name, const_string tc_file, std::size_t tc_line )
 {
     return new test_case( ut_detail::normalize_test_case_name( tc_name ), tc_file, tc_line, test_func );
 }

--- a/include/boost/test/unit_test_monitor.hpp
+++ b/include/boost/test/unit_test_monitor.hpp
@@ -44,7 +44,7 @@ public:
     static bool is_critical_error( error_level e ) { return e <= fatal_error; }
 
     // monitor method
-    error_level execute_and_translate( boost::function<void ()> const& func, unsigned timeout = 0 );
+    error_level execute_and_translate( test_func_t const& func, unsigned timeout = 0 );
 
 private:
     BOOST_TEST_SINGLETON_CONS( unit_test_monitor_t )

--- a/include/boost/test/unit_test_suite.hpp
+++ b/include/boost/test/unit_test_suite.hpp
@@ -33,7 +33,7 @@
 // ************************************************************************** //
 
 #define BOOST_TEST_CASE( test_function )                                   \
-boost::unit_test::make_test_case( boost::function<void ()>(test_function), \
+boost::unit_test::make_test_case( boost::unit_test::test_func_t(test_function), \
                                   BOOST_TEST_STRINGIZE( test_function ),   \
                                   __FILE__, __LINE__ )
 #define BOOST_CLASS_TEST_CASE( test_function, tc_instance )                \

--- a/include/boost/test/utils/runtime/argument_factory.hpp
+++ b/include/boost/test/utils/runtime/argument_factory.hpp
@@ -24,8 +24,12 @@
 #include <boost/test/utils/basic_cstring/compare.hpp>
 #include <boost/test/utils/string_cast.hpp>
 
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
 // Boost
 #include <boost/function/function2.hpp>
+#else
+#include <functional>
+#endif
 
 // STL
 #include <vector>

--- a/include/boost/test/utils/runtime/cla/parser.hpp
+++ b/include/boost/test/utils/runtime/cla/parser.hpp
@@ -47,7 +47,11 @@ namespace rt_cla_detail {
 struct parameter_trie;
 typedef shared_ptr<parameter_trie> parameter_trie_ptr;
 typedef std::map<char,parameter_trie_ptr> trie_per_char;
-typedef std::vector<boost::reference_wrapper<parameter_cla_id const> > param_cla_id_list;
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+    typedef std::vector<boost::reference_wrapper<parameter_cla_id const> > param_cla_id_list;
+#else
+    using param_cla_id_list = std::vector<std::reference_wrapper<parameter_cla_id const>>;
+#endif
 
 struct parameter_trie {
     parameter_trie() : m_has_final_candidate( false ) {}
@@ -82,8 +86,11 @@ struct parameter_trie {
                               << "parameter cla id " << m_id_candidates.back().get().m_tag );
 
         m_has_final_candidate = final;
-        m_id_candidates.push_back( ref(param_id) );
-
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+        m_id_candidates.push_back( boost::ref(param_id) );
+#else
+        m_id_candidates.push_back( std::ref(param_id) );
+#endif
         if( m_id_candidates.size() == 1 )
             m_param_candidate = param_candidate;
         else

--- a/include/boost/test/utils/runtime/parameter.hpp
+++ b/include/boost/test/utils/runtime/parameter.hpp
@@ -26,8 +26,13 @@
 #include <boost/test/utils/foreach.hpp>
 
 // Boost
-#include <boost/function/function2.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
+#include <boost/function/function2.hpp>
+#else
+#include <functional>
+#endif
 
 // STL
 #include <algorithm>
@@ -91,7 +96,12 @@ typedef std::vector<parameter_cla_id> param_cla_ids;
 cstring const help_prefix("////");
 
 class basic_param {
+
+#if defined(BOOST_NO_CXX11_HDR_FUNCTIONAL)
     typedef function<void (cstring)>            callback_type;
+#else
+    using callback_type = std::function<void (cstring)>;
+#endif
     typedef unit_test::readwrite_property<bool> bool_property;
 
 protected:

--- a/test/test-organization-ts/test_unit-order-shuffled-test.cpp
+++ b/test/test-organization-ts/test_unit-order-shuffled-test.cpp
@@ -94,7 +94,7 @@ struct test_tree {
         for(std::size_t s = 0; s < 10; s++)
         {
             ut::test_case* tc = boost::unit_test::make_test_case(
-                                    boost::function<void ()>(some_test),
+                                    boost::unit_test::test_func_t(some_test),
                                     "tc_" +  boost::unit_test::utils::string_cast(s),
                                     __FILE__, __LINE__ );
             tsuites[std::rand() % tsuites.size()]->add(tc);

--- a/test/test-organization-ts/test_unit-order-test.cpp
+++ b/test/test-organization-ts/test_unit-order-test.cpp
@@ -29,7 +29,7 @@ namespace tt = boost::test_tools;
 
 void some_test() {}
 #define TC( name )                                                      \
-boost::unit_test::make_test_case( boost::function<void ()>(some_test),  \
+boost::unit_test::make_test_case( boost::unit_test::test_func_t(some_test), \
                                   BOOST_TEST_STRINGIZE( name ),         \
                                   __FILE__, __LINE__ )
 


### PR DESCRIPTION
All except one test green. 
`test-tree-management-test` is failing as somehow the conversion of `std::function` to `bool` is not working as expected in 
`BOOST_TEST( tc1->p_test_func );` in line 118
Tested c++03 compatibility with gcc-6.2 in c++03 mode
