### PR TITLE
[clang] Fix [-Wc++11-narrowing] error

### DIFF
--- a/include/boost/test/utils/basic_cstring/basic_cstring.hpp
+++ b/include/boost/test/utils/basic_cstring/basic_cstring.hpp
@@ -60,13 +60,7 @@ public:
 
     // !! should also present reverse_iterator, const_reverse_iterator
 
-#if !BOOST_WORKAROUND(__IBMCPP__, BOOST_TESTED_AT(600))
-    enum npos_type { npos = static_cast<size_type>(-1) };
-#else
-    // IBM/VisualAge version 6 is not able to handle enums larger than 4 bytes.
-    // But size_type is 8 bytes in 64bit mode.
-    static const size_type npos = -1 ;
-#endif
+    BOOST_STATIC_CONSTANT(size_type, npos = static_cast<size_type>(-1));
 
     static pointer  null_str();
 


### PR DESCRIPTION
Compiling on Windows with clang this code:

#define BOOST_TEST_MODULE The Test
#include <boost/test/included/unit_test.hpp>

command:

"clang.exe" -c -x c++ test.cpp -Iboost -fno-ms-compatibility

produces:

boost/test/utils/basic_cstring/basic_cstring.hpp:64:29: error: enumerator value evaluates to 18446744073709551615, which cannot be narrowed to type 'int' [-Wc++11-narrowing]

Not tested it with IBM/VisualAge, but boost\config\compiler\vacpp.hpp only defines BOOST_NO_INCLASS_MEMBER_INITIALIZATION for IBMCPP <= 502, so BOOST_STATIC_CONSTANT should expand to "static const". Anyway, if anything go wrong, it is BOOST_STATIC_CONSTANT to blame, not Boost.Test.