### PR TITLE
fix compiler warning

### DIFF
--- a/include/boost/test/impl/compiler_log_formatter.ipp
+++ b/include/boost/test/impl/compiler_log_formatter.ipp
@@ -282,7 +282,7 @@ compiler_log_formatter::entry_context_finish( std::ostream& output, log_level l 
 //____________________________________________________________________________//
 
 void
-compiler_log_formatter::log_entry_context( std::ostream& output, log_level l, const_string context_descr )
+compiler_log_formatter::log_entry_context( std::ostream& output, log_level /*l*/, const_string context_descr )
 {
     output << "\n    " << context_descr;
 }


### PR DESCRIPTION
I'm not certain if this is correct - but "l" isn't used currently.