### PR TITLE
Fix use-after-free of s_frk_state()::the_inst

### DIFF
--- a/include/boost/test/impl/framework.ipp
+++ b/include/boost/test/impl/framework.ipp
@@ -490,7 +490,8 @@ unsigned const TIMEOUT_EXCEEDED = static_cast<unsigned>( -1 );
 class state {
 public:
     state()
-    : m_curr_test_unit( INV_TEST_UNIT_ID )
+    : m_master_test_suite(0)
+    , m_curr_test_unit( INV_TEST_UNIT_ID )
     , m_next_test_case_id( MIN_TEST_CASE_ID )
     , m_next_test_suite_id( MIN_TEST_SUITE_ID )
     , m_test_in_progress( false )
@@ -880,11 +881,7 @@ public:
 namespace impl {
 namespace {
 
-#if defined(__CYGWIN__)
 framework::state& s_frk_state() { static framework::state* the_inst = 0; if(!the_inst) the_inst = new framework::state; return *the_inst; }
-#else
-framework::state& s_frk_state() { static framework::state the_inst; return the_inst; }
-#endif
 
 } // local namespace
 


### PR DESCRIPTION
s_frk_state()::the_inst is a statically scoped object that is
referred to by another statically scoped object, s_log_impl()::the_inst.
Since the ordering of destruction among statically scoped objects that
are defined in different translation units is not defined, we can observe
s_frk_state()::the_inst being destroyed before s_log_impl()::the_inst,
leading to a use-after-free when the latter is destroyed.

"Fix" by intentionally leaking s_frk_state::the_inst.  We also need to
initialize its member m_master_test_suite, which can be initialized to
a random value when allocating from the heap, leading a later test
of that member to fail.

Addresses issue 13371.