### PR TITLE
Silence 'unused variable' warning

### DIFF
--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -938,7 +938,7 @@ attach_debugger( bool break_or_continue )
     return true;
 
 #else // ****************************************************** default
-
+    (void) break_or_continue; // silence 'unused variable' warning
     return false;
 
 #endif


### PR DESCRIPTION
Mac OS doesn't fall into the "UNIX based debugging" or "windows based debugging", so we get the "do nothing" behavior.