### PR TITLE
Add option to wait for keypress before application terminates

### DIFF
--- a/doc/runtime_configuration/runtime_config_reference.qbk
+++ b/doc/runtime_configuration/runtime_config_reference.qbk
@@ -556,6 +556,26 @@ a default value. The only acceptable values are string names of output formats (
 [endsect] [/output_format]
 
 [/ ###############################################################################################]
+[section:pause_on_exit `pause_on_exit`]
+
+Parameter ['pause_on_exit] instructs the __UTF__ to wait until a button is pressed before the
+test executable terminates. This feature is turned off by default.
+
+[h4 Acceptable values]
+
+[link boolean_param_value Boolean] with default value [*no].
+
+[h4 Command line syntax]
+
+* `--pause_on_exit[=<boolean value>]`
+
+[h4 Environment variable]
+
+  BOOST_TEST_PAUSE_ON_EXIT
+
+[endsect] [/pause_on_exit]
+
+[/ ###############################################################################################]
 [section:random `random`]
 
 Parameter ['random] instructs the __UTF__ to execute the test cases in random order. This parameter

--- a/doc/runtime_configuration/runtime_config_summary.qbk
+++ b/doc/runtime_configuration/runtime_config_summary.qbk
@@ -99,6 +99,12 @@
 
   [/ ###############################################################################################]
   [
+    [[link boost_test.utf_reference.rt_param_reference.pause_on_exit `pause_on_exit`]]
+    [Wait for button press before terminating the test executable.]
+  ]
+
+  [/ ###############################################################################################]
+  [
     [[link boost_test.utf_reference.rt_param_reference.random `random`]]
     [Instructs the framework to run the tests in random order]
   ]

--- a/include/boost/test/impl/unit_test_main.ipp
+++ b/include/boost/test/impl/unit_test_main.ipp
@@ -174,6 +174,19 @@ private:
     std::set<std::string>   m_labels;
 };
 
+// ************************************************************************** //
+// **************                wait_for_keypress             ************** //
+// ************************************************************************** //
+
+void wait_for_keypress()
+{
+    results_reporter::get_stream() << "Press enter to continue..." << std::endl;
+
+    // getchar is defined as a macro in uClibc. Use parenthesis to fix
+    // gcc bug 58952 for gcc <= 4.8.2.
+    (std::getchar)();
+}
+
 } // namespace ut_detail
 
 // ************************************************************************** //
@@ -189,11 +202,7 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
         framework::init( init_func, argc, argv );
 
         if( runtime_config::get<bool>( runtime_config::btrt_wait_for_debugger ) ) {
-            results_reporter::get_stream() << "Press any key to continue..." << std::endl;
-
-            // getchar is defined as a macro in uClibc. Use parenthesis to fix
-            // gcc bug 58952 for gcc <= 4.8.2.
-            (std::getchar)();
+            ut_detail::wait_for_keypress();
             results_reporter::get_stream() << "Continuing..." << std::endl;
         }
 
@@ -254,6 +263,10 @@ unit_test_main( init_unit_test_func init_func, int argc, char* argv[] )
     }
 
     framework::shutdown();
+
+    if( runtime_config::get<bool>( runtime_config::btrt_pause_on_exit ) ) {
+        ut_detail::wait_for_keypress();
+    }
 
     return result_code;
 }

--- a/include/boost/test/impl/unit_test_parameters.ipp
+++ b/include/boost/test/impl/unit_test_parameters.ipp
@@ -84,6 +84,7 @@ std::string btrt_log_level         = "log_level";
 std::string btrt_log_sink          = "log_sink";
 std::string btrt_combined_logger   = "logger";
 std::string btrt_output_format     = "output_format";
+std::string btrt_pause_on_exit     = "pause_on_exit";
 std::string btrt_random_seed       = "random";
 std::string btrt_report_format     = "report_format";
 std::string btrt_report_level      = "report_level";
@@ -391,6 +392,18 @@ register_parameters( rt::parameters_store& store )
     output_format.add_cla_id( "--", btrt_output_format, "=" );
     output_format.add_cla_id( "-", "o", " " );
     store.add( output_format );
+
+    ///////////////////////////////////////////////
+
+    rt::option pause_on_exit( btrt_pause_on_exit, (
+        rt::description = "Wait for button press before terminating the test executable.",
+        rt::env_var = "BOOST_TEST_PAUSE_ON_EXIT",
+        rt::help = "Instructs the framework to pause before terminating the test executable. "
+                   "This feature is turned off by default."
+    ));
+
+    pause_on_exit.add_cla_id( "--", btrt_pause_on_exit, "=" );
+    store.add( pause_on_exit );
 
     /////////////////////////////////////////////// combined logger option
 

--- a/include/boost/test/unit_test_parameters.hpp
+++ b/include/boost/test/unit_test_parameters.hpp
@@ -61,6 +61,7 @@ BOOST_TEST_DECL extern std::string btrt_save_test_pattern;
 BOOST_TEST_DECL extern std::string btrt_show_progress;
 BOOST_TEST_DECL extern std::string btrt_use_alt_stack;
 BOOST_TEST_DECL extern std::string btrt_wait_for_debugger;
+BOOST_TEST_DECL extern std::string btrt_pause_on_exit;
 BOOST_TEST_DECL extern std::string btrt_help;
 BOOST_TEST_DECL extern std::string btrt_usage;
 BOOST_TEST_DECL extern std::string btrt_version;


### PR DESCRIPTION
I've added a command line parameter to pause execution until a key is pressed. This should be very useful if you run tests directly in Visual Studio with attached debugger because Visual Studio just closes the console window after the application terminates.