### PR TITLE
Fix stdcerr file creation on shutdown

### DIFF
--- a/include/boost/test/impl/framework.ipp
+++ b/include/boost/test/impl/framework.ipp
@@ -913,7 +913,7 @@ void
 shutdown_loggers_and_reports()
 {
     s_frk_state().m_log_sinks.clear();
-    s_frk_state().m_report_sink.setup( "stdcerr" );
+    s_frk_state().m_report_sink.setup( "stderr" );
 }
 
 void


### PR DESCRIPTION
The problem was originally reported here:

https://github.com/boostorg/log/issues/51
