### PR TITLE
Change Windows.h include to all-lowercase.

### DIFF
--- a/include/boost/test/utils/setcolor.hpp
+++ b/include/boost/test/utils/setcolor.hpp
@@ -25,7 +25,7 @@
 #include <boost/test/detail/suppress_warnings.hpp>
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 
   #if defined(__MINGW32__) && !defined(COMMON_LVB_UNDERSCORE)
     // mingw badly mimicking windows.h


### PR DESCRIPTION
Otherwise cross-compiling with MinGW on Linux
will fail.