### PR TITLE
Fix compilation with gcc 4.6 and older

### DIFF
--- a/include/boost/test/tree/test_case_template.hpp
+++ b/include/boost/test/tree/test_case_template.hpp
@@ -169,9 +169,9 @@ public:
     // Constructor
     template_test_case_gen( const_string tc_name, const_string tc_file, std::size_t tc_line )
     {
-        using tuple_t = std::tuple<tuple_parameter_pack...>;
-        using this_type = template_test_case_gen<TestCaseTemplate, tuple_t >;
-        using single_test_gen = generate_test_case_4_type<this_type, TestCaseTemplate>;
+        typedef std::tuple<tuple_parameter_pack...> tuple_t;
+        typedef template_test_case_gen<TestCaseTemplate, tuple_t > this_type;
+        typedef generate_test_case_4_type<this_type, TestCaseTemplate> single_test_gen;
 
         single_test_gen op( tc_name, tc_file, tc_line, *this );
 


### PR DESCRIPTION
The compiler does not support the "using" syntax for typedefs, even non-template, until gcc 4.7.

This should fix these test failures:

https://www.boost.org/development/tests/develop/developer/output/igaztanaga-develop-gcc-4-6c++11-boost-bin-v2-libs-log-test-attr_attribute_set-test-gcc-4-6c+-dbg-dbg-symbl-off-thrdp-wn32-thrd-mlt.html
https://www.boost.org/development/tests/develop/developer/output/teeks99-02-dg4-4-warn-Docker-64on64-boost-bin-v2-libs-log-test-attr_attribute_set-test-gcc-4-4~c++0x~warn-debug-threadapi-pthread-threading-multi.html

Untested.
