### PR TITLE
Make under_debugger work on apple (iOS/macOS)

### DIFF
--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -102,6 +102,15 @@ namespace std { using ::memset; using ::sprintf; }
 
 #  endif
 
+#elif defined(__APPLE__) // ********************* APPLE
+
+#  define BOOST_APPLE_BASED_DEBUG
+
+#  include <assert.h>
+#  include <sys/types.h>
+#  include <unistd.h>
+#  include <sys/sysctl.h>
+
 #endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
@@ -655,6 +664,33 @@ under_debugger()
     }
 
     return false;
+
+#elif defined(BOOST_APPLE_BASED_DEBUG) // ********************** APPLE
+
+  // See https://developer.apple.com/library/mac/qa/qa1361/_index.html
+  int                 junk;
+  int                 mib[4];
+  struct kinfo_proc   info;
+  size_t              size;
+
+  // Initialize the flags so that, if sysctl fails for some bizarre
+  // reason, we get a predictable result.
+  info.kp_proc.p_flag = 0;
+
+  // Initialize mib, which tells sysctl the info we want, in this case
+  // we're looking for information about a specific process ID.
+  mib[0] = CTL_KERN;
+  mib[1] = KERN_PROC;
+  mib[2] = KERN_PROC_PID;
+  mib[3] = getpid();
+
+  // Call sysctl.
+  size = sizeof(info);
+  junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+  assert(junk == 0);
+
+  // We're being debugged if the P_TRACED flag is set.
+  return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
 
 #else // ****************************************************** default
 


### PR DESCRIPTION
Simply uses the documented way from Apple to detect the debugger: https://developer.apple.com/library/content/qa/qa1361/_index.html