### PR TITLE
Fix warning: BOOST_CLANG is not defined, evaluates to 0

### DIFF
--- a/include/boost/test/detail/enable_warnings.hpp
+++ b/include/boost/test/detail/enable_warnings.hpp
@@ -26,7 +26,7 @@
 # pragma warning(pop)
 #endif
 
-#if BOOST_CLANG
+#ifdef BOOST_CLANG
 #pragma clang diagnostic pop
 #endif
 

--- a/include/boost/test/detail/suppress_warnings.hpp
+++ b/include/boost/test/detail/suppress_warnings.hpp
@@ -26,7 +26,7 @@
 # pragma warning(disable: 4511) // 'class' : copy constructor could not be generated
 #endif
 
-#if BOOST_CLANG
+#ifdef BOOST_CLANG
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wvariadic-macros"
 #endif


### PR DESCRIPTION
The diagnostic is issued when compiled with GCC/clang flag `-Wundef`.

Although in case `BOOST_CLANG` is not defined, ie. is not a macro and `BOOST_CLANG` identifier is considered to be zero, the `#ifdef` directive makes the intention clearer.