### PR TITLE
When specifying --color_output=no, don't output color codes

### DIFF
--- a/include/boost/test/impl/compiler_log_formatter.ipp
+++ b/include/boost/test/impl/compiler_log_formatter.ipp
@@ -183,29 +183,29 @@ compiler_log_formatter::log_entry_start( std::ostream& output, log_entry_data co
         case BOOST_UTL_ET_INFO:
             print_prefix( output, entry_data.m_file_name, entry_data.m_line_num );
             if( m_color_output )
-                output << setcolor( term_attr::BRIGHT, term_color::GREEN );
+                output << setcolor( m_color_output, term_attr::BRIGHT, term_color::GREEN );
             output << "info: ";
             break;
         case BOOST_UTL_ET_MESSAGE:
             if( m_color_output )
-                output << setcolor( term_attr::BRIGHT, term_color::CYAN );
+                output << setcolor( m_color_output, term_attr::BRIGHT, term_color::CYAN );
             break;
         case BOOST_UTL_ET_WARNING:
             print_prefix( output, entry_data.m_file_name, entry_data.m_line_num );
             if( m_color_output )
-                output << setcolor( term_attr::BRIGHT, term_color::YELLOW );
+                output << setcolor( m_color_output, term_attr::BRIGHT, term_color::YELLOW );
             output << "warning: in \"" << test_phase_identifier() << "\": ";
             break;
         case BOOST_UTL_ET_ERROR:
             print_prefix( output, entry_data.m_file_name, entry_data.m_line_num );
             if( m_color_output )
-                output << setcolor( term_attr::BRIGHT, term_color::RED );
+                output << setcolor( m_color_output, term_attr::BRIGHT, term_color::RED );
             output << "error: in \"" << test_phase_identifier() << "\": ";
             break;
         case BOOST_UTL_ET_FATAL_ERROR:
             print_prefix( output, entry_data.m_file_name, entry_data.m_line_num );
             if( m_color_output )
-                output << setcolor( term_attr::UNDERLINE, term_color::RED );
+                output << setcolor( m_color_output, term_attr::UNDERLINE, term_color::RED );
             output << "fatal error: in \"" << test_phase_identifier() << "\": ";
             break;
     }


### PR DESCRIPTION
As described in https://github.com/boostorg/test/issues/149, specifying `--color_output=no` still will output the color codes, it just outputs the codes for "normal" output.

A better approach would be if the user disables color output completely, the codes should not be included at all.  This PR attempts to do that.