### PR TITLE
Correct library name in test runner help screen

### DIFF
--- a/include/boost/test/utils/runtime/cla/parser.hpp
+++ b/include/boost/test/utils/runtime/cla/parser.hpp
@@ -109,12 +109,12 @@ struct parameter_trie {
 // **************      runtime::cla::report_foreing_token      ************** //
 // ************************************************************************** //
 
-static void 
+static void
 report_foreing_token( cstring program_name, cstring token )
 {
     std::cerr << "Boost.Test WARNING: token \"" << token << "\" does not correspond to the Boost.Test argument \n"
               << "                    and should be placed after all Boost.Test arguments and the -- separator.\n"
-              << "                    For example: " << program_name << " --random -- " << token << "\n"; 
+              << "                    For example: " << program_name << " --random -- " << token << "\n";
 }
 
 } // namespace rt_cla_detail
@@ -203,7 +203,7 @@ public:
 
             if( negative_form ) {
                 BOOST_TEST_I_ASSRT( found_id.m_negatable,
-                                    format_error( found_param->p_name ) 
+                                    format_error( found_param->p_name )
                                         << "Parameter tag " << found_id.m_tag << " is not negatable." );
 
                 curr_token.trim_left( m_negation_prefix.size() );
@@ -213,16 +213,16 @@ public:
 
             bool should_go_to_next = true;
             cstring value;
-          
+
 
             // Skip validations if parameter has optional value and we are at the end of token
             if( !value_separator.is_empty() || !found_param->p_has_optional_value ) {
-            
+
                 // we are given a separator or there is no optional value
-            
+
                 // Validate and skip value separator in the input
                 BOOST_TEST_I_ASSRT( found_id.m_value_separator == value_separator,
-                                    format_error( found_param->p_name ) 
+                                    format_error( found_param->p_name )
                                         << "Invalid separator for the parameter "
                                         << found_param->p_name
                                         << " in the argument " << tr.current_token() );
@@ -247,7 +247,7 @@ public:
                 value = curr_token;
                 if( value.is_empty() ) {
                     tr.next_token(); // tokenization broke the value, we check the next one
-                  
+
                     if(!found_param->p_has_optional_value) {
                         // there is no separator and there is no optional value
                         // we look for the value on the next token
@@ -261,7 +261,7 @@ public:
                         // example "-c" (defaults to true)
                         // and commit this as the value if this is not a token
                         cstring value_check = tr.current_token();
-                  
+
                         cstring prefix_test, name_test, value_separator_test;
                         bool negative_form_test;
                         if( validate_token_format( value_check, prefix_test, name_test, value_separator_test, negative_form_test )
@@ -328,7 +328,7 @@ public:
     }
 
     void
-    usage(std::ostream& ostr, 
+    usage(std::ostream& ostr,
           cstring param_name = cstring(),
           bool use_color = true)
     {
@@ -340,13 +340,13 @@ public:
             param->usage( ostr, m_negation_prefix );
         }
         else {
-            ostr << "\n  The program '" << m_program_name << "' is a Boost.test module containing unit tests.";
-            
+            ostr << "\n  The program '" << m_program_name << "' is a Boost.Test module containing unit tests.";
+
             {
               BOOST_TEST_SCOPE_SETCOLOR( use_color, ostr, term_attr::BRIGHT, term_color::ORIGINAL );
               ostr << "\n\n  Usage\n    ";
             }
-            
+
             {
                 BOOST_TEST_SCOPE_SETCOLOR( use_color, ostr, term_attr::BRIGHT, term_color::GREEN );
                 ostr << m_program_name << " [Boost.Test argument]... ";
@@ -359,7 +359,7 @@ public:
 
         ostr << "\n\n  Use\n      ";
         {
-            
+
             BOOST_TEST_SCOPE_SETCOLOR( use_color, ostr, term_attr::BRIGHT, term_color::GREEN );
             ostr << m_program_name << " --help";
         }
@@ -372,8 +372,8 @@ public:
     }
 
     void
-    help(std::ostream& ostr, 
-         parameters_store const& parameters, 
+    help(std::ostream& ostr,
+         parameters_store const& parameters,
          cstring param_name,
          bool use_color = true)
     {
@@ -431,10 +431,10 @@ public:
 
         ostr << "\n\n  The following parameters are supported:\n";
 
-        BOOST_TEST_FOREACH( 
-            parameters_store::storage_type::value_type const&, 
-            v, 
-            parameters.all() ) 
+        BOOST_TEST_FOREACH(
+            parameters_store::storage_type::value_type const&,
+            v,
+            parameters.all() )
         {
             basic_param_ptr param = v.second;
             ostr << "\n";


### PR DESCRIPTION
Just correct `Boost.Test` name at line 343 and remove several trailing spaces.