### PR TITLE
Check for non-used variables when NDEBUG is defined

### DIFF
--- a/include/boost/test/impl/junit_log_formatter.ipp
+++ b/include/boost/test/impl/junit_log_formatter.ipp
@@ -525,16 +525,26 @@ junit_log_formatter::test_unit_start( std::ostream& /*ostr*/, test_unit const& t
 
 //____________________________________________________________________________//
 
+#ifndef NDEBUG
 void
 junit_log_formatter::test_unit_finish( std::ostream& /*ostr*/, test_unit const& tu, unsigned long /*elapsed*/ )
+#else
+void
+junit_log_formatter::test_unit_finish( std::ostream& /*ostr*/, test_unit const& /*tu*/, unsigned long /*elapsed*/ )
+#endif
 {
     // the time is already stored in the result_reporter
     assert( tu.p_id == list_path_to_root.back() );
     list_path_to_root.pop_back();
 }
 
+#ifndef NDEBUG 
 void
 junit_log_formatter::test_unit_aborted( std::ostream& /*ostr*/, test_unit const& tu )
+#else
+void
+junit_log_formatter::test_unit_aborted( std::ostream& /*ostr*/, test_unit const& /*tu*/ )
+#endif
 {
     assert( tu.p_id == list_path_to_root.back() );
     //list_path_to_root.pop_back();


### PR DESCRIPTION
When NDEBUG is defined, the compiler may warn about variables not used. They are only used in assert's.