### PR TITLE
enable BOOST_TEST with tolerance and user-message

### DIFF
--- a/include/boost/test/tools/assertion_result.hpp
+++ b/include/boost/test/tools/assertion_result.hpp
@@ -82,6 +82,10 @@ private:
 
 typedef assertion_result predicate_result;
 
+template<typename T>
+inline assertion_result const&
+operator<<(assertion_result const& as, T const&) { return as; }
+
 } // namespace test_tools
 } // namespace boost
 

--- a/include/boost/test/tools/detail/tolerance_manip.hpp
+++ b/include/boost/test/tools/detail/tolerance_manip.hpp
@@ -68,15 +68,34 @@ operator<<(assertion_evaluate_t<E> const& ae, tolerance_manip<FPT> const& tol)
 
 //____________________________________________________________________________//
 
+struct tolerance_manip_terminal {
+    unit_test::lazy_ostream const& ostr;
+    operator boost::unit_test::lazy_ostream const&() const { return ostr; }
+};
+
 template<typename FPT>
-inline int
-operator<<( unit_test::lazy_ostream const&, tolerance_manip<FPT> const& )   { return 0; }
+inline tolerance_manip_terminal
+operator<<(unit_test::lazy_ostream const& ostr, tolerance_manip<FPT> const&) { return tolerance_manip_terminal{ ostr }; }
+
+template<typename T>
+inline tolerance_manip_terminal
+operator<<(tolerance_manip_terminal tmt, T const&) { return tmt; }
 
 //____________________________________________________________________________//
 
 template<typename FPT>
 inline check_type
 operator<<( assertion_type const& /*at*/, tolerance_manip<FPT> const& )         { return CHECK_BUILT_ASSERTION; }
+
+template<typename T>
+inline check_type
+operator<<(check_type chk, T const&) { return chk; }
+
+//____________________________________________________________________________//
+
+template<typename FPT>
+inline std::ostream&
+operator<<(std::ostream& ostr, tolerance_manip<FPT> const&)    { return ostr; }
 
 //____________________________________________________________________________//
 


### PR DESCRIPTION
the additional operator << allow using BOOST_TEST with tolerance and user-message, e.g 

BOOST_TEST(a == b, "a not equals b" << boost::test_tools::tolerance(0.000001));