### PR TITLE
fix warning on gcc-7.3 in cygwin claiming master_test_suite is declared differently

### DIFF
--- a/include/boost/test/tree/test_unit.hpp
+++ b/include/boost/test/tree/test_unit.hpp
@@ -229,7 +229,7 @@ public:
     int      argc;
     char**   argv;
   
-    friend master_test_suite_t& boost::unit_test::framework::master_test_suite();
+    friend BOOST_TEST_DECL master_test_suite_t& boost::unit_test::framework::master_test_suite();
 };
 
 // ************************************************************************** //


### PR DESCRIPTION
See an example here:
https://ci.appveyor.com/project/jeking3/thread/builds/20518379/job/m0ppxtti4invy0ka?fullLog=true#L1459

```
gcc.compile.c++ bin.v2\libs\thread\test\test_thread_exit.test\gcc-7.3.0\rls\cxstd-03-iso\trgt-os-cygwn\thrdp-pthrd\thrd-mlt\vsblt-hdn\test_thread_exit.o
In file included from ./boost/test/tree/auto_registration.hpp:21:0,
                 from ./boost/test/unit_test_suite.hpp:17,
                 from ./boost/test/unit_test.hpp:19,
                 from libs\thread\test\test_thread_exit.cpp:17:
./boost/test/tree/test_unit.hpp:232:33: warning: 'boost::unit_test::master_test_suite_t& boost::unit_test::framework::master_test_suite()' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
     friend master_test_suite_t& boost::unit_test::framework::master_test_suite();
                                 ^~~~~
```
