### PR TITLE
Fix MinGW compilation problems

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -48,7 +48,9 @@
 #include <cassert>              // for assert
 #include <cstddef>              // for NULL
 #include <cstdio>               // for vsnprintf
+#include <stdio.h>
 #include <cstdarg>              // for varargs
+#include <stdarg.h>
 
 #include <iostream>              // for varargs
 
@@ -57,15 +59,7 @@ namespace std { using ::strerror; using ::strlen; using ::strncat; }
 #endif
 
 // to use vsnprintf
-#if defined(__SUNPRO_CC) || defined(__SunOS)
-#  include <stdio.h>
-#  include <stdarg.h>
-using std::va_list;
-#endif
-
-// to use vsnprintf
-#if defined(__QNXNTO__) || defined(__VXWORKS__)
-#  include <stdio.h>
+#if defined(__SUNPRO_CC) || defined(__SunOS) || defined(__QNXNTO__) || defined(__VXWORKS__)
 using std::va_list;
 #endif
 

--- a/include/boost/test/tree/test_unit.hpp
+++ b/include/boost/test/tree/test_unit.hpp
@@ -229,7 +229,7 @@ public:
     int      argc;
     char**   argv;
   
-    friend master_test_suite_t& boost::unit_test::framework::master_test_suite();
+    friend BOOST_TEST_DECL master_test_suite_t& boost::unit_test::framework::master_test_suite();
 };
 
 // ************************************************************************** //


### PR DESCRIPTION
This fixes problems with MinGW gcc 5.3 that were discovered in Boost.Log CI [builds](https://ci.appveyor.com/project/Lastique/log/build/job/v59mk63a0swtdic1):

- `master_test_suite` function redeclared without `dllimport`
- `vsnprintf` not declared

The latter problem I couldn't reproduce locally, but I guess it is caused by a missing include of stdio.h. If that doesn't help, another fix might be needed.
