### PR TITLE
Fix MinGW vsnprintf compile errors and warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,112 @@
+# Copyright 2019 Andrey Semashev
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - master
+    - develop
+    - /topic\/.*/
+
+environment:
+  matrix:
+# AppVeyor doesn't provide 64-bit compilers for these MSVC versions
+#    - TOOLSET: msvc-9.0
+#      ADDRESS_MODEL: 64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#    - TOOLSET: msvc-10.0
+#      ADDRESS_MODEL: 64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#    - TOOLSET: msvc-11.0
+#      ADDRESS_MODEL: 64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-12.0
+      ADDRESS_MODEL: 64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-14.0
+      ADDRESS_MODEL: 64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-14.1
+      ADDRESS_MODEL: 64
+      EXTRA_TESTS: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 64
+      CXXSTD: 03,11
+      ADDPATH: C:\cygwin64\bin
+      EXTRA_TESTS: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 64
+      CXXSTD: 03,11,14
+      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
+      EXTRA_TESTS: 1
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 64
+      CXXSTD: 03,11,14,17
+      ADDPATH: C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    - TOOLSET: msvc-9.0
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-10.0
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-11.0
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-12.0
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-14.0
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: msvc-14.1
+      ADDRESS_MODEL: 32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 32
+      CXXSTD: 03,11
+      ADDPATH: C:\cygwin\bin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 32
+      CXXSTD: 03,11
+      ADDPATH: C:\mingw\bin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - TOOLSET: gcc
+      ADDRESS_MODEL: 32
+      CXXSTD: 03,11,14
+      ADDPATH: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+install:
+  - set GIT_FETCH_JOBS=8
+  - set BOOST_BRANCH=develop
+  - if "%APPVEYOR_REPO_BRANCH%" == "master" set BOOST_BRANCH=master
+  - cd ..
+  - git clone -b %BOOST_BRANCH% https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule init tools/boostdep
+  - git submodule init tools/build
+  - git submodule init tools/boost_install
+  - git submodule init libs/headers
+  - git submodule init libs/config
+  - git submodule update --jobs %GIT_FETCH_JOBS%
+  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\test
+  - python tools/boostdep/depinst/depinst.py --include example --include doc/examples --git_args "--jobs %GIT_FETCH_JOBS%" test
+  - cmd /c bootstrap
+  - b2 headers
+
+build: off
+
+test_script:
+  - PATH=%ADDPATH%;%PATH%
+  - if not "%CXXSTD%" == "" set CXXSTD=cxxstd=%CXXSTD%
+  - b2 -j %NUMBER_OF_PROCESSORS% libs/test/test variant=release toolset=%TOOLSET% address-model=%ADDRESS_MODEL% %CXXSTD% %B2_ARGS%

--- a/include/boost/test/data/monomorphic/generators/keywords.hpp
+++ b/include/boost/test/data/monomorphic/generators/keywords.hpp
@@ -25,9 +25,9 @@ namespace unit_test {
 namespace data {
 
 namespace {
-nfp::keyword<struct begin_t>    begin;
-nfp::keyword<struct end_t>      end;
-nfp::keyword<struct step_t>     step;
+nfp::keyword<struct begin_t>    begin BOOST_ATTRIBUTE_UNUSED;
+nfp::keyword<struct end_t>      end   BOOST_ATTRIBUTE_UNUSED;
+nfp::keyword<struct step_t>     step  BOOST_ATTRIBUTE_UNUSED;
 } // local namespace
 
 } // namespace data

--- a/include/boost/test/detail/global_typedef.hpp
+++ b/include/boost/test/detail/global_typedef.hpp
@@ -125,12 +125,12 @@ private:                                                \
 
 #if defined(__APPLE_CC__) && defined(__GNUC__) && __GNUC__ < 4
 #define BOOST_TEST_SINGLETON_INST( inst ) \
-static BOOST_JOIN( inst, _t)& inst = BOOST_JOIN (inst, _t)::instance();
+static BOOST_JOIN( inst, _t)& inst BOOST_ATTRIBUTE_UNUSED = BOOST_JOIN (inst, _t)::instance();
 
 #else
 
 #define BOOST_TEST_SINGLETON_INST( inst ) \
-namespace { BOOST_JOIN( inst, _t)& inst = BOOST_JOIN( inst, _t)::instance(); }
+namespace { BOOST_JOIN( inst, _t)& inst BOOST_ATTRIBUTE_UNUSED = BOOST_JOIN( inst, _t)::instance(); }
 
 #endif
 

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -208,7 +208,8 @@ namespace detail {
 #  define BOOST_TEST_VSNPRINTF( a1, a2, a3, a4 ) std::vsnprintf( (a1), (a2), (a3), (a4) )
 #elif BOOST_WORKAROUND(_MSC_VER, <= 1310) || \
       BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3000)) || \
-      defined(UNDER_CE)
+      defined(UNDER_CE) || \
+      (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 #  define BOOST_TEST_VSNPRINTF( a1, a2, a3, a4 ) _vsnprintf( (a1), (a2), (a3), (a4) )
 #else
 #  define BOOST_TEST_VSNPRINTF( a1, a2, a3, a4 ) vsnprintf( (a1), (a2), (a3), (a4) )

--- a/include/boost/test/unit_test_suite.hpp
+++ b/include/boost/test/unit_test_suite.hpp
@@ -322,7 +322,7 @@ static boost::unit_test::ut_detail::global_fixture_impl<F> BOOST_JOIN( gf_, F ) 
 
 #define BOOST_TEST_DECORATOR( D )                                       \
 static boost::unit_test::decorator::collector_t const&                  \
-BOOST_TEST_APPEND_UNIQUE_ID(decorator_collector) = D;                   \
+BOOST_TEST_APPEND_UNIQUE_ID(decorator_collector) BOOST_ATTRIBUTE_UNUSED = D; \
 /**/
 
 // ************************************************************************** //
@@ -362,7 +362,7 @@ typedef ::boost::unit_test::ut_detail::nil_t BOOST_AUTO_TEST_CASE_FIXTURE;
 
 #define BOOST_AUTO_TU_REGISTRAR( test_name )                       \
 static boost::unit_test::ut_detail::auto_test_unit_registrar       \
-BOOST_TEST_APPEND_UNIQUE_ID( BOOST_JOIN( test_name, _registrar ) ) \
+BOOST_TEST_APPEND_UNIQUE_ID( BOOST_JOIN( test_name, _registrar ) ) BOOST_ATTRIBUTE_UNUSED \
 /**/
 #define BOOST_AUTO_TC_INVOKER( test_name )      BOOST_JOIN( test_name, _invoker )
 #define BOOST_AUTO_TC_UNIQUE_ID( test_name )    BOOST_JOIN( test_name, _id )


### PR DESCRIPTION
This PR:

- Adds Appveyor CI config file.
- Fixes compile errors on MinGW about missing declaration of `vsnprintf`. The attempted fix in https://github.com/boostorg/test/pull/195, although correct, did not fix the error.
- Silences gcc warnings about unused global variables.
