### PR TITLE
Comment 'ar' parameter of assertion_result to avoid warning

### DIFF
--- a/include/boost/test/tree/observer.hpp
+++ b/include/boost/test/tree/observer.hpp
@@ -85,7 +85,7 @@ public:
     //! - an unexpected exception is caught by the Boost.Test framework
     virtual void    test_unit_aborted( test_unit const& ) {}
 
-    virtual void    assertion_result( unit_test::assertion_result ar )
+    virtual void    assertion_result( unit_test::assertion_result /* ar */ )
     {
         /*
         switch( ar ) {


### PR DESCRIPTION
This should help to avoid the warning compiling tests that (indirectly) use this public header with `-Wunused-parameter` or equivalent flag. For example, ~100 instances of the warning is issued when compiling tests of Boost.GIL.