### PR TITLE
Fixes an issue with sun_cc lacking the __global attribute for enums

### DIFF
--- a/include/boost/test/detail/config.hpp
+++ b/include/boost/test/detail/config.hpp
@@ -78,6 +78,14 @@ class type_info;
 
 //____________________________________________________________________________//
 
+#if defined(__SUNPRO_CC)
+#define BOOST_TEST_ENUM_SYMBOL_VISIBLE
+#else
+#define BOOST_TEST_ENUM_SYMBOL_VISIBLE BOOST_SYMBOL_VISIBLE
+#endif
+
+//____________________________________________________________________________//
+
 #if defined(BOOST_ALL_DYN_LINK) && !defined(BOOST_TEST_DYN_LINK)
 #  define BOOST_TEST_DYN_LINK
 #endif

--- a/include/boost/test/detail/log_level.hpp
+++ b/include/boost/test/detail/log_level.hpp
@@ -22,7 +22,7 @@ namespace unit_test {
 // ************************************************************************** //
 
 //  each log level includes all subsequent higher loging levels
-enum BOOST_SYMBOL_VISIBLE log_level {
+enum BOOST_TEST_ENUM_SYMBOL_VISIBLE log_level {
     invalid_log_level        = -1,
     log_successful_tests     = 0,
     log_test_units           = 1,


### PR DESCRIPTION
Fixes an issue with sun_cc lacking the __global attribute for enums, reported as an issue in #213 

https://docs.oracle.com/cd/E19205-01/819-5267/bkaed/index.html  