### PR TITLE
Commented out unused argument name (stack_decorator::apply)

### DIFF
--- a/include/boost/test/impl/decorator.ipp
+++ b/include/boost/test/impl/decorator.ipp
@@ -111,7 +111,7 @@ stack_decorator::operator*() const
 }
 
 void
-stack_decorator::apply( test_unit& tu )
+stack_decorator::apply( test_unit& /*tu*/ )
 {
     // does nothing by definition
 }


### PR DESCRIPTION
Both GCC and Clang complain about the argument to `stack_decorator::apply` being unused; commenting out the variable name quiets the warning