### PR TITLE
Add printf format checking attribute to report_error

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -242,7 +242,7 @@ extract( boost::exception const* ex )
 //____________________________________________________________________________//
 
 static void
-#ifdef __GNUC__
+#if __GNUC__ >= 3
 __attribute__((__format__ (__printf__, 3, 0)))
 #endif
 report_error( execution_exception::error_code ec, boost::exception const* be, char const* format, va_list* args )
@@ -263,7 +263,7 @@ report_error( execution_exception::error_code ec, boost::exception const* be, ch
 //____________________________________________________________________________//
 
 static void
-#ifdef __GNUC__
+#if __GNUC__ >= 3
 __attribute__((__format__ (__printf__, 3, 4)))
 #endif
 report_error( execution_exception::error_code ec, boost::exception const* be, char const* format, ... )
@@ -279,7 +279,7 @@ report_error( execution_exception::error_code ec, boost::exception const* be, ch
 //____________________________________________________________________________//
 
 static void
-#ifdef __GNUC__
+#if __GNUC__ >= 3
 __attribute__((__format__ (__printf__, 2, 3)))
 #endif
 report_error( execution_exception::error_code ec, char const* format, ... )

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -242,6 +242,9 @@ extract( boost::exception const* ex )
 //____________________________________________________________________________//
 
 static void
+#ifdef __GNUC__
+__attribute__((__format__ (__printf__, 3, 0)))
+#endif
 report_error( execution_exception::error_code ec, boost::exception const* be, char const* format, va_list* args )
 {
     static const int REPORT_ERROR_BUFFER_SIZE = 4096;
@@ -260,6 +263,9 @@ report_error( execution_exception::error_code ec, boost::exception const* be, ch
 //____________________________________________________________________________//
 
 static void
+#ifdef __GNUC__
+__attribute__((__format__ (__printf__, 3, 4)))
+#endif
 report_error( execution_exception::error_code ec, boost::exception const* be, char const* format, ... )
 {
     va_list args;
@@ -273,6 +279,9 @@ report_error( execution_exception::error_code ec, boost::exception const* be, ch
 //____________________________________________________________________________//
 
 static void
+#ifdef __GNUC__
+__attribute__((__format__ (__printf__, 2, 3)))
+#endif
 report_error( execution_exception::error_code ec, char const* format, ... )
 {
     va_list args;
@@ -410,48 +419,48 @@ system_signal_exception::report() const
         case ILL_ILLOPC:
             report_error( execution_exception::system_fatal_error,
                           "signal: illegal opcode; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_ILLTRP:
             report_error( execution_exception::system_fatal_error,
                           "signal: illegal trap; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_PRVREG:
             report_error( execution_exception::system_fatal_error,
                           "signal: privileged register; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_BADSTK:
             report_error( execution_exception::system_fatal_error,
                           "signal: internal stack error; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
 #endif
         case ILL_ILLOPN:
             report_error( execution_exception::system_fatal_error,
                           "signal: illegal operand; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_ILLADR:
             report_error( execution_exception::system_fatal_error,
                           "signal: illegal addressing mode; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_PRVOPC:
             report_error( execution_exception::system_fatal_error,
                           "signal: privileged opcode; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case ILL_COPROC:
             report_error( execution_exception::system_fatal_error,
                           "signal: co-processor error; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         default:
             report_error( execution_exception::system_fatal_error,
                           "signal: SIGILL, si_code: %d (illegal instruction; address of failing instruction: 0x%08lx)",
-                          m_sig_info->si_addr, m_sig_info->si_code );
+                          m_sig_info->si_code, (uintptr_t) m_sig_info->si_addr );
             break;
         }
         break;
@@ -461,47 +470,47 @@ system_signal_exception::report() const
         case FPE_INTDIV:
             report_error( execution_exception::system_error,
                           "signal: integer divide by zero; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_INTOVF:
             report_error( execution_exception::system_error,
                           "signal: integer overflow; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTDIV:
             report_error( execution_exception::system_error,
                           "signal: floating point divide by zero; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTOVF:
             report_error( execution_exception::system_error,
                           "signal: floating point overflow; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTUND:
             report_error( execution_exception::system_error,
                           "signal: floating point underflow; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTRES:
             report_error( execution_exception::system_error,
                           "signal: floating point inexact result; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTINV:
             report_error( execution_exception::system_error,
                           "signal: invalid floating point operation; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case FPE_FLTSUB:
             report_error( execution_exception::system_error,
                           "signal: subscript out of range; address of failing instruction: 0x%08lx",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         default:
             report_error( execution_exception::system_error,
                           "signal: SIGFPE, si_code: %d (errnoneous arithmetic operations; address of failing instruction: 0x%08lx)",
-                          m_sig_info->si_addr, m_sig_info->si_code );
+                          m_sig_info->si_code, (uintptr_t) m_sig_info->si_addr );
             break;
         }
         break;
@@ -512,18 +521,18 @@ system_signal_exception::report() const
         case SEGV_MAPERR:
             report_error( execution_exception::system_fatal_error,
                           "memory access violation at address: 0x%08lx: no mapping at fault address",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case SEGV_ACCERR:
             report_error( execution_exception::system_fatal_error,
                           "memory access violation at address: 0x%08lx: invalid permissions",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
 #endif
         default:
             report_error( execution_exception::system_fatal_error,
                           "signal: SIGSEGV, si_code: %d (memory access violation at address: 0x%08lx)",
-                          m_sig_info->si_addr, m_sig_info->si_code );
+                          m_sig_info->si_code, (uintptr_t) m_sig_info->si_addr );
             break;
         }
         break;
@@ -534,23 +543,23 @@ system_signal_exception::report() const
         case BUS_ADRALN:
             report_error( execution_exception::system_fatal_error,
                           "memory access violation at address: 0x%08lx: invalid address alignment",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case BUS_ADRERR:
             report_error( execution_exception::system_fatal_error,
                           "memory access violation at address: 0x%08lx: non-existent physical address",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
         case BUS_OBJERR:
             report_error( execution_exception::system_fatal_error,
                           "memory access violation at address: 0x%08lx: object specific hardware error",
-                          m_sig_info->si_addr );
+                          (uintptr_t) m_sig_info->si_addr );
             break;
 #endif
         default:
             report_error( execution_exception::system_fatal_error,
                           "signal: SIGSEGV, si_code: %d (memory access violation at address: 0x%08lx)",
-                          m_sig_info->si_addr, m_sig_info->si_code );
+                          m_sig_info->si_code, (uintptr_t) m_sig_info->si_addr );
             break;
         }
         break;
@@ -596,7 +605,7 @@ system_signal_exception::report() const
         default:
             report_error( execution_exception::system_error,
                           "signal: SIGPOLL, si_code: %d (asynchronous I/O event occurred; band event %d)",
-                          (int)m_sig_info->si_band, m_sig_info->si_code );
+                          m_sig_info->si_code, (int)m_sig_info->si_band );
             break;
         }
         break;
@@ -1298,7 +1307,7 @@ execution_monitor::execute( boost::function<int ()> const& F )
 #if defined(BOOST_NO_TYPEID) || defined(BOOST_NO_RTTI)
                               "unknown boost::exception" ); }
 #else
-                              boost::diagnostic_information(ex).c_str() ); }
+                              "%s", boost::diagnostic_information(ex).c_str() ); }
 #endif
 
     //  std:: exceptions

--- a/test/execution_monitor-ts/boost_exception-test.cpp
+++ b/test/execution_monitor-ts/boost_exception-test.cpp
@@ -25,12 +25,13 @@ using boost::test_tools::output_test_stream;
 using namespace boost::unit_test;
 
 typedef boost::error_info<struct tag_error_code, boost::uint32_t> error_code;
+typedef boost::error_info<struct tag_error_string, std::string> error_string;
 struct myexception : std::exception, virtual boost::exception
 {};
 
 // this one should generate a message as it does not execute any assertion
 void exception_raised() {
-    BOOST_THROW_EXCEPTION( myexception() << error_code(123) );
+    BOOST_THROW_EXCEPTION( myexception() << error_code(123) << error_string("error%%string") );
 }
 
 struct output_test_stream2 : public output_test_stream {
@@ -60,8 +61,11 @@ BOOST_AUTO_TEST_CASE( test_logs )
     // the message is "Dynamic exception type: boost::exception_detail::clone_impl<myexception>" on Unix
     // and "Dynamic exception type: boost::exception_detail::clone_impl<struct myexception>" on Windows.
     // Also contains "[tag_error_code*] = 123" on Unix and "[struct tag_error_code * __ptr64] = 123" On Windows
+    // Also contains "[tag_error_string*] = error%%string" on Unix and "[struct tag_error_string * __ptr64] = error%%string" On Windows
     BOOST_TEST(error_string.find("tag_error_code") != std::string::npos);
     BOOST_TEST(error_string.find("= 123") != std::string::npos);
+    BOOST_TEST(error_string.find("tag_error_string") != std::string::npos);
+    BOOST_TEST(error_string.find("= error%%string") != std::string::npos);
     BOOST_TEST(error_string.find("Dynamic exception type") != std::string::npos);
     BOOST_TEST(error_string.find("boost::wrapexcept<") != std::string::npos);
     BOOST_TEST(error_string.find("myexception>") != std::string::npos);


### PR DESCRIPTION
On gcc and clang, add `__attribute__((__format__))` checking to the `report_error` function.

Note: clang warns `-Wformat-nonliteral` (off by default, but good practice) when a format string argument not annotated by `__attribute__((__format__))` is passed to `vprintf` etc.; gcc does not. See https://clang.llvm.org/docs/AttributeReference.html#format .

Plus fixes for bugs exposed by this change:
* Cast faulting addresses to `uintptr_t` for formatting as `0x%08lx`. If there is an LLP64 platform that uses Posix signals (i.e. not Win64, which uses SEH) this should be changed to use `PRIxPTR` format specifier.
* Fix swapped `si_code`/`si_addr` (& `si_band`) format arguments.
* Add missing `%s` to format diagnostic information.