### PR TITLE
fix timeout in windows

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1185,7 +1185,7 @@ execution_monitor::catch_signals( boost::function<int ()> const& F )
 
         if( htimer != INVALID_HANDLE_VALUE ) {
             LARGE_INTEGER liDueTime;
-            liDueTime.QuadPart = - static_cast<signed long long int>(p_timeout) * 10ll; // resolution of 100 ns
+            liDueTime.QuadPart = - static_cast<LONGLONG>(p_timeout) * 10ll; // resolution of 100 ns
 
             bTimerSuccess = ::SetWaitableTimer(
                 htimer,

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1185,7 +1185,7 @@ execution_monitor::catch_signals( boost::function<int ()> const& F )
 
         if( htimer != INVALID_HANDLE_VALUE ) {
             LARGE_INTEGER liDueTime;
-            liDueTime.QuadPart = - static_cast<signed long long int>(p_timeout) * 10l; // resolution of 100 ns
+            liDueTime.QuadPart = - static_cast<signed long long int>(p_timeout) * 10ll; // resolution of 100 ns
 
             bTimerSuccess = ::SetWaitableTimer(
                 htimer,

--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1185,7 +1185,7 @@ execution_monitor::catch_signals( boost::function<int ()> const& F )
 
         if( htimer != INVALID_HANDLE_VALUE ) {
             LARGE_INTEGER liDueTime;
-            liDueTime.QuadPart = - static_cast<signed long int>(p_timeout) * 10; // resolution of 100 ns
+            liDueTime.QuadPart = - static_cast<signed long long int>(p_timeout) * 10l; // resolution of 100 ns
 
             bTimerSuccess = ::SetWaitableTimer(
                 htimer,


### PR DESCRIPTION
Visual studio 2019 + Boost 1.71.0 + Windows 10 64bit

I use boost test with timeout(240) like below, it will timeout error.

```cpp
BOOST_AUTO_TEST_CASE(TEST, *boost::unit_test::timeout(240)) {
    BOOST_TEST_INFO(1);
}
```

DueTime is 64bit, but `static_cast<signed long int>(p_timeout) * 10` will 32bit and timeout value will overflow.


