### PR TITLE
boost::diagnostic_information() works in no rtti mode.

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -1309,11 +1309,7 @@ execution_monitor::execute( boost::function<int ()> const& F )
     catch( boost::exception const& ex )
       { detail::report_error( execution_exception::cpp_exception_error,
                               &ex,
-#if defined(BOOST_NO_TYPEID) || defined(BOOST_NO_RTTI)
-                              "unknown boost::exception" ); }
-#else
                               "%s", boost::diagnostic_information(ex).c_str() ); }
-#endif
 
     //  std:: exceptions
 #if defined(BOOST_NO_TYPEID) || defined(BOOST_NO_RTTI)


### PR DESCRIPTION
boost::exception processes `BOOST_NO_TYPEID` and `BOOST_NO_RTTI` inside more flexible.