### PR TITLE
Use __linux__ instead of __linux.

### DIFF
--- a/include/boost/test/impl/debug.ipp
+++ b/include/boost/test/impl/debug.ipp
@@ -84,7 +84,7 @@ namespace std { using ::memset; using ::sprintf; }
 
 #    include <procfs.h>
 
-#  elif defined(linux) || defined(__linux)
+#  elif defined(linux) || defined(__linux__)
 
 #    define BOOST_LINUX_BASED_DEBUG
 


### PR DESCRIPTION
The macro __linux is less portable and, for example, is not defined on
some architectures.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=28314.