### PR TITLE
Fix compilation issue due to deleted std::basic_ostream::operator<< o…

### DIFF
--- a/include/boost/test/impl/test_tools.ipp
+++ b/include/boost/test/impl/test_tools.ipp
@@ -124,7 +124,7 @@ print_log_value<char const*>::operator()( std::ostream& ostr, char const* t )
 void
 print_log_value<wchar_t const*>::operator()( std::ostream& ostr, wchar_t const* t )
 {
-    ostr << ( t ? t : L"null string" );
+    ostr << ( t ? reinterpret_cast<char const*>(t) : "null string" );
 }
 
 //____________________________________________________________________________//


### PR DESCRIPTION
This PR tries to fix the following compilation error:
```
In file included from libs/test/src/test_tools.cpp:16:
./boost/test/impl/test_tools.ipp: In member function ‘void boost::test_tools::tt_detail::print_log_value<const wchar_t*>::operator()(std::ostream&, const wchar_t*)’:                                                                                                                    ./boost/test/impl/test_tools.ipp:127:38: error: use of deleted function ‘std::basic_ostream<char, _Traits>& std::operator<<(std::basic_ostream<char, _Traits>&, const wchar_t*) [with _Traits = std::char_traits<char>]’                                                                   127 |     ostr << ( t ? t : L"null string" );
      |                                      ^
In file included from /remote/tools/Linux/2.6/1A/toolchain/x86_64-v20.0.8/include/c++/10.0.1/istream:39,
                 from /remote/tools/Linux/2.6/1A/toolchain/x86_64-v20.0.8/include/c++/10.0.1/sstream:38,
                 from ./boost/test/utils/wrap_stringstream.hpp:26,                                                                                                                                                                                                                                        from ./boost/test/unit_test_log.hpp:24,
                 from ./boost/test/tools/old/impl.hpp:19,
                 from ./boost/test/test_tools.hpp:46,
                 from ./boost/test/impl/test_tools.ipp:19,
                 from libs/test/src/test_tools.cpp:16:                                                                                                                                                                                                                                   /remote/tools/Linux/2.6/1A/toolchain/x86_64-v20.0.8/include/c++/10.0.1/ostream:634:5: note: declared here                                                                                                                                                                                  634 |     operator<<(basic_ostream<char, _Traits>&, const wchar_t*) = delete;
      |     ^~~~~~~~
```
The root cause is that many std::basic_ostream::operator<< overload were marked as deleted: https://en.cppreference.com/w/cpp/io/basic_ostream/operator_ltlt2