### PR TITLE
Avoid deprecated bind placeholders in global namespace

### DIFF
--- a/include/boost/test/data/test_case.hpp
+++ b/include/boost/test/data/test_case.hpp
@@ -32,7 +32,7 @@
 #include <boost/preprocessor/control/iif.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/type_traits/is_copy_constructible.hpp>
 
 #include <boost/test/tools/detail/print_helper.hpp>

--- a/include/boost/test/impl/framework.ipp
+++ b/include/boost/test/impl/framework.ipp
@@ -49,7 +49,7 @@
 
 // Boost
 #include <boost/test/utils/timer.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 // STL
 #include <limits>

--- a/include/boost/test/parameterized_test.hpp
+++ b/include/boost/test/parameterized_test.hpp
@@ -20,7 +20,7 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function/function1.hpp>
 
 #include <boost/test/detail/suppress_warnings.hpp>

--- a/test/writing-test-ts/test_tools-test.cpp
+++ b/test/writing-test-ts/test_tools-test.cpp
@@ -25,7 +25,7 @@
 #include <boost/test/detail/suppress_warnings.hpp>
 
 // Boost
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/noncopyable.hpp>
 
 // STL
@@ -464,6 +464,7 @@ TEST_CASE( test_BOOST_CHECK_PREDICATE )
     using std::not_equal_to;
     BOOST_CHECK_PREDICATE( not_equal_to<int>(), (i)(17) );
 
+    using namespace boost::placeholders;
     int j=15;
     BOOST_CHECK_PREDICATE( boost::bind( is_even, boost::bind( &foo, _1, _2 ) ), (i)(j) );
 


### PR DESCRIPTION
This fixes numerous yet annoying compilation warnings:

```
  note: #pragma message:
    The practice of declaring the Bind placeholders (_1, _2, ...)
    in the global namespace is deprecated.
    Please use <boost/bind/bind.hpp> + using namespace boost::placeholders,
    or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.
```

Apart from obscuring the output of compilation of libraries using Boost.Test, it may be troublesome on CI builds. On many CI services every line of log counts and if log dumps become too long, 
builds are terminated.