### PR TITLE
Use macOS API only on macOS

### DIFF
--- a/include/boost/test/utils/timer.hpp
+++ b/include/boost/test/utils/timer.hpp
@@ -18,7 +18,7 @@
 
 # if defined(_WIN32) || defined(__CYGWIN__)
 #   define BOOST_TEST_TIMER_WINDOWS_API
-# elif defined(__MACH__)// && !defined(CLOCK_MONOTONIC)
+# elif defined(__MACH__) && defined(__APPLE__)// && !defined(CLOCK_MONOTONIC)
 #   // we compile for all macs the same, CLOCK_MONOTONIC introduced in 10.12
 #   define BOOST_TEST_TIMER_MACH_API
 # else


### PR DESCRIPTION
`__MACH__` matches any Mach-based OS, which means both macOS and GNU/Hurd; since the API used is really specific to macOS, then also check for `__APPLE__`.

This fixes the build on GNU/Hurd.