### PR TITLE
C++20 compatibility for print_log_value<>

### DIFF
--- a/include/boost/test/impl/test_tools.ipp
+++ b/include/boost/test/impl/test_tools.ipp
@@ -121,11 +121,15 @@ print_log_value<char const*>::operator()( std::ostream& ostr, char const* t )
 
 //____________________________________________________________________________//
 
+#if __cplusplus <= 201703L
+
 void
 print_log_value<wchar_t const*>::operator()( std::ostream& ostr, wchar_t const* t )
 {
     ostr << ( t ? reinterpret_cast<const void*>(t) : "null string" );
 }
+
+#endif
 
 //____________________________________________________________________________//
 

--- a/include/boost/test/tools/detail/print_helper.hpp
+++ b/include/boost/test/tools/detail/print_helper.hpp
@@ -160,10 +160,14 @@ struct BOOST_TEST_DECL print_log_value<char const*> {
 
 //____________________________________________________________________________//
 
+#if __cplusplus <= 201703L
+
 template<>
 struct BOOST_TEST_DECL print_log_value<wchar_t const*> {
     void    operator()( std::ostream& ostr, wchar_t const* t );
 };
+
+#endif
 
 #if !defined(BOOST_NO_CXX11_NULLPTR)
 template<>


### PR DESCRIPTION
operator<<(std::ostream&, const wchar_t*) has been removed from C++20 [1].
Remove the corresponding print_log_value<> specialization.