### PR TITLE
Use boost_test_print_type customization point in lazy_ostream

### DIFF
--- a/include/boost/test/utils/lazy_ostream.hpp
+++ b/include/boost/test/utils/lazy_ostream.hpp
@@ -13,6 +13,7 @@
 
 // Boost.Test
 #include <boost/test/detail/config.hpp>
+#include <boost/test/tools/detail/print_helper.hpp>
 
 // STL
 #include <iosfwd>
@@ -78,7 +79,7 @@ public:
 
     std::ostream&   operator()( std::ostream& ostr ) const BOOST_OVERRIDE
     {
-        return m_prev(ostr) << m_value;
+        return m_prev(ostr) << test_tools::tt_detail::print_helper(m_value);
     }
 private:
     // Data members

--- a/test/writing-test-ts/user-defined-types-logging-customization-points.cpp
+++ b/test/writing-test-ts/user-defined-types-logging-customization-points.cpp
@@ -40,6 +40,7 @@ BOOST_AUTO_TEST_CASE(test1)
 #ifndef BOOST_TEST_MACRO_LIMITED_SUPPORT
     BOOST_TEST(t == 10);
 #endif
+    BOOST_TEST_MESSAGE("Printing t: " << t);
 }
 
 // on unary expressions as well
@@ -53,4 +54,5 @@ std::ostream &boost_test_print_type(std::ostream &o, const s &) {
 BOOST_AUTO_TEST_CASE( test_logs )
 {
     BOOST_TEST(s());
+    BOOST_TEST_MESSAGE("Printing s(): " << s());
 }


### PR DESCRIPTION
This makes BOOST_TEST_MESSAGE(x) consistent with BOOST_TEST(x).