### PR TITLE
Export execution_aborted exception to allow catching it from outside the DLL

### DIFF
--- a/include/boost/test/execution_monitor.hpp
+++ b/include/boost/test/execution_monitor.hpp
@@ -479,7 +479,7 @@ execution_monitor::register_exception_translator( ExceptionTranslator const& tr,
 /// @brief This is a trivial default constructible class. Use it to report graceful abortion of a monitored function execution.
 // ************************************************************************** //
 
-struct execution_aborted {};
+struct BOOST_SYMBOL_VISIBLE execution_aborted {};
 
 // ************************************************************************** //
 // **************                  system_error                ************** //


### PR DESCRIPTION
In our code we have encapsulated testcase execution into a dedicated method where we do some housekeeping.

The code looks like this:

```
    try
    {
        // execute the testcase
    }
    catch (const boost::execution_aborted&) {
        throw; // we let this exception propagate to ensure Boost.Test works as designed
    }
    catch (...) { // one of our exceptions
        // we do some housekeeping and then call BOOST_FAIL()
    }

```

However to let boost::execution_aborted exceptions propagate it is necessary for the type to be exported from the DLL. Otherwise the exception simply cannot be caught in the main program and always ends up in the catch-all handler.