### PR TITLE
Fix errors due to non-explicit conversions of tribool to bool

### DIFF
--- a/include/boost/test/tools/assertion_result.hpp
+++ b/include/boost/test/tools/assertion_result.hpp
@@ -54,7 +54,7 @@ public:
     {}
 
     template<typename BoolConvertable>
-    assertion_result( BoolConvertable const& pv_ ) : p_predicate_value( !!pv_ ) {}
+    assertion_result( BoolConvertable const& pv_ ) : p_predicate_value( !!static_cast<bool>(pv_) ) {}
 
     // Access methods
     bool                operator!() const           { return !p_predicate_value; }

--- a/include/boost/test/tools/old/interface.hpp
+++ b/include/boost/test/tools/old/interface.hpp
@@ -78,17 +78,17 @@ do {                                                                            
 //____________________________________________________________________________//
 
 #define BOOST_WARN( P )                     BOOST_TEST_TOOL_IMPL( 2, \
-    (P), BOOST_TEST_STRINGIZE( P ), WARN, CHECK_PRED, _ )
+    static_cast<bool>(P), BOOST_TEST_STRINGIZE( P ), WARN, CHECK_PRED, _ )
 #define BOOST_CHECK( P )                    BOOST_TEST_TOOL_IMPL( 2, \
-    (P), BOOST_TEST_STRINGIZE( P ), CHECK, CHECK_PRED, _ )
+    static_cast<bool>(P), BOOST_TEST_STRINGIZE( P ), CHECK, CHECK_PRED, _ )
 #define BOOST_REQUIRE( P )                  BOOST_TEST_TOOL_IMPL( 2, \
-    (P), BOOST_TEST_STRINGIZE( P ), REQUIRE, CHECK_PRED, _ )
+    static_cast<bool>(P), BOOST_TEST_STRINGIZE( P ), REQUIRE, CHECK_PRED, _ )
 
 //____________________________________________________________________________//
 
-#define BOOST_WARN_MESSAGE( P, M )          BOOST_TEST_TOOL_IMPL( 2, (P), M, WARN, CHECK_MSG, _ )
-#define BOOST_CHECK_MESSAGE( P, M )         BOOST_TEST_TOOL_IMPL( 2, (P), M, CHECK, CHECK_MSG, _ )
-#define BOOST_REQUIRE_MESSAGE( P, M )       BOOST_TEST_TOOL_IMPL( 2, (P), M, REQUIRE, CHECK_MSG, _ )
+#define BOOST_WARN_MESSAGE( P, M )          BOOST_TEST_TOOL_IMPL( 2, static_cast<bool>(P), M, WARN, CHECK_MSG, _ )
+#define BOOST_CHECK_MESSAGE( P, M )         BOOST_TEST_TOOL_IMPL( 2, static_cast<bool>(P), M, CHECK, CHECK_MSG, _ )
+#define BOOST_REQUIRE_MESSAGE( P, M )       BOOST_TEST_TOOL_IMPL( 2, static_cast<bool>(P), M, REQUIRE, CHECK_MSG, _ )
 
 //____________________________________________________________________________//
 


### PR DESCRIPTION
This fixes errors like the following that occur with newer compiler versions:

```
/usr/include/boost/test/tools/assertion_result.hpp:57:79: error: no matching function for call to ‘boost::test_tools::assertion_result::readonly_property65::readonly_property65(boost::logic::tribool)’
   57 |     assertion_result( BoolConvertable const& pv_ ) : p_predicate_value( !!pv_ ) {}
      |                                                                               ^
```