### PR TITLE
Web assembly has no support for an alternate stack.

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -163,7 +163,7 @@ namespace { void _set_se_translator( void* ) {} }
 
 // documentation of BOOST_TEST_DISABLE_ALT_STACK in execution_monitor.hpp
 #  if !defined(__CYGWIN__) && !defined(__QNXNTO__) && !defined(__bgq__) && \
-   (!defined(__ANDROID__) || __ANDROID_API__ >= 8) && \
+   (!defined(__ANDROID__) || __ANDROID_API__ >= 8) && !defined(__wasm__) && \
    !defined(BOOST_TEST_DISABLE_ALT_STACK)
 #    define BOOST_TEST_USE_ALT_STACK
 #  endif


### PR DESCRIPTION
Fixes usage of Boost.Test when compiling for web assembly with emscripten.