### PR TITLE
Apply catch_system_errors option to m_aux_em

### DIFF
--- a/include/boost/test/impl/framework.ipp
+++ b/include/boost/test/impl/framework.ipp
@@ -1204,6 +1204,7 @@ init( init_unit_test_func init_func, int argc, char* argv[] )
     master_test_suite().argv = argv;
 
     // 70. Invoke test module initialization routine
+    s_frk_state().m_aux_em.p_catch_system_errors.value = runtime_config::get<bool>( runtime_config::btrt_catch_sys_errors );
     BOOST_TEST_I_TRY {
         s_frk_state().m_aux_em.vexecute( boost::bind( &impl::invoke_init_func, init_func ) );
     }


### PR DESCRIPTION
That way it is respected also in init_unit_test_suite.
This allows handling these in some other way even in
that function, and it also allows to install custom
signal handling from within init_unit_test_suite,
instead of the workaround of implementing a custom
main() function.