### PR TITLE
Remove ::boost::test_tools::tt_detail::dummy_cond

### DIFF
--- a/include/boost/test/tools/detail/fwd.hpp
+++ b/include/boost/test/tools/detail/fwd.hpp
@@ -42,8 +42,6 @@ class assertion_result;
 
 namespace tt_detail {
 
-inline bool dummy_cond() { return false; }
-
 // ************************************************************************** //
 // **************        types of supported assertions         ************** //
 // ************************************************************************** //

--- a/include/boost/test/tools/interface.hpp
+++ b/include/boost/test/tools/interface.hpp
@@ -55,7 +55,7 @@ do {                                                            \
         ::boost::test_tools::tt_detail::level,                  \
         ::boost::test_tools::tt_detail::CHECK_MSG,              \
         0 );                                                    \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )         \
+} while( 0 )                                                    \
 /**/
 
 //____________________________________________________________________________//
@@ -74,7 +74,7 @@ do {                                                            \
       ::boost::test_tools::tt_detail::level,                    \
       ::boost::test_tools::tt_detail::CHECK_BUILT_ASSERTION,    \
       0 );                                                      \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )         \
+} while( 0 )                                                    \
 /**/
 
 //____________________________________________________________________________//
@@ -98,7 +98,7 @@ do {                                                            \
       ::boost::test_tools::tt_detail::assertion_type()          \
           << arg,                                               \
       0 );                                                      \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )         \
+} while( 0 )                                                    \
 /**/
 
 //____________________________________________________________________________//
@@ -121,7 +121,7 @@ do {                                                                        \
         BOOST_TEST_TOOL_DIRECT_IMPL( P, level, BOOST_TEST_STRINGIZE( P ) ); \
     else                                                                    \
         BOOST_TEST_TOOL_ET_IMPL( P, level );                                \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )                     \
+} while( 0 )                                                                \
 /**/
 
 #define BOOST_TEST_TOOL_UNIV_EX( level, P, ... )                            \
@@ -177,7 +177,7 @@ do { try {                                                                  \
     BOOST_TEST_TOOL_DIRECT_IMPL( Ppassed, TL, Mpassed );                    \
 } catch( E ) {                                                              \
     BOOST_TEST_TOOL_DIRECT_IMPL( Pcaught, TL, Mcaught );                    \
-}} while( ::boost::test_tools::tt_detail::dummy_cond() )                    \
+}} while( 0 )                                                               \
 /**/
 
 #elif defined(BOOST_TEST_TOOLS_DEBUGGABLE)
@@ -190,7 +190,7 @@ do { try {                                                                  \
     BOOST_TEST_TOOL_DIRECT_IMPL( Ppassed, TL, Mpassed );                    \
 } catch( E ) {                                                              \
     BOOST_TEST_TOOL_DIRECT_IMPL( Pcaught, TL, Mcaught );                    \
-}} while( ::boost::test_tools::tt_detail::dummy_cond() )                    \
+}} while( 0 )                                                               \
 /**/
 
 #else
@@ -202,7 +202,7 @@ do { try {                                                                  \
     BOOST_TEST_TOOL_DIRECT_IMPL( Ppassed, TL, Mpassed );                    \
 } catch( E ) {                                                              \
     BOOST_TEST_TOOL_DIRECT_IMPL( Pcaught, TL, Mcaught );                    \
-}} while( ::boost::test_tools::tt_detail::dummy_cond() )                    \
+}} while( 0 )                                                               \
 /**/
 
 #endif

--- a/include/boost/test/tools/old/interface.hpp
+++ b/include/boost/test/tools/old/interface.hpp
@@ -72,7 +72,7 @@ do {                                                                            
         ::boost::test_tools::tt_detail::TL,                                     \
         ::boost::test_tools::tt_detail::CT                                      \
         BOOST_JOIN( BOOST_TEST_TOOL_PASS_ARGS, frwd_type )( ARGS ) );           \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )                         \
+} while( 0 )                                                                    \
 /**/
 
 //____________________________________________________________________________//
@@ -110,7 +110,7 @@ do {                                                                            
                               "exception \"" BOOST_STRINGIZE( E )"\" raised as expected" postfix,   \
                               TL, CHECK_MSG, _  );                                      \
     }                                                                                   \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )                                 \
+} while( 0 )                                                                            \
 /**/
 
 //____________________________________________________________________________//
@@ -140,7 +140,7 @@ do {                                                                            
         BOOST_TEST_TOOL_IMPL( 2, false, "unexpected exception thrown by " BOOST_STRINGIZE( S ),    \
                               TL, CHECK_MSG, _ );                                       \
     }                                                                                   \
-} while( ::boost::test_tools::tt_detail::dummy_cond() )                                 \
+} while( 0 )                                                                            \
 /**/
 
 #define BOOST_WARN_NO_THROW( S )            BOOST_CHECK_NO_THROW_IMPL( S, WARN )


### PR DESCRIPTION
Replace loops using it by simple do { ... } while (0) loops.
This allows static analysis tools like clang-tidy to better understand
the code and avoid false positives.

Fixes #343.