### PR TITLE
Fix for sprintf deprecation warning

### DIFF
--- a/include/boost/test/utils/setcolor.hpp
+++ b/include/boost/test/utils/setcolor.hpp
@@ -90,8 +90,11 @@ public:
                           state* /* unused */= NULL)
     : m_is_color_output(is_color_output)
     {
-        m_command_size = boost::core::snprintf( m_control_command, 
-          sizeof(m_control_command), 
+        #ifdef BOOST_MSVC
+        m_command_size = std::sprintf( m_control_command,
+        #else
+        m_command_size = boost::core::snprintf( m_control_command, sizeof(m_control_command), 
+        #endif
           "%c[%c;3%c;4%cm",
           0x1B,
           static_cast<char>(attr + '0'),
@@ -103,8 +106,11 @@ public:
                          state* /* unused */)
     : m_is_color_output(is_color_output)
     {
-        m_command_size = boost::core::snprintf(m_control_command, 
-          sizeof(m_control_command), 
+        #ifdef BOOST_MSVC
+        m_command_size = std::sprintf( m_control_command, 
+        #else
+        m_command_size = boost::core::snprintf(m_control_command, sizeof(m_control_command), 
+        #endif
           "%c[%c;3%c;4%cm",
           0x1B,
           static_cast<char>(term_attr::NORMAL + '0'),

--- a/include/boost/test/utils/setcolor.hpp
+++ b/include/boost/test/utils/setcolor.hpp
@@ -19,6 +19,7 @@
 #include <boost/test/detail/config.hpp>
 
 #include <boost/core/ignore_unused.hpp>
+#include <boost/core/snprintf.hpp>
 
 // STL
 #include <iostream>
@@ -89,7 +90,9 @@ public:
                           state* /* unused */= NULL)
     : m_is_color_output(is_color_output)
     {
-        m_command_size = std::sprintf( m_control_command, "%c[%c;3%c;4%cm",
+        m_command_size = boost::core::snprintf( m_control_command, 
+          sizeof(m_control_command), 
+          "%c[%c;3%c;4%cm",
           0x1B,
           static_cast<char>(attr + '0'),
           static_cast<char>(fg + '0'),
@@ -100,7 +103,9 @@ public:
                          state* /* unused */)
     : m_is_color_output(is_color_output)
     {
-        m_command_size = std::sprintf(m_control_command, "%c[%c;3%c;4%cm",
+        m_command_size = boost::core::snprintf(m_control_command, 
+          sizeof(m_control_command), 
+          "%c[%c;3%c;4%cm",
           0x1B,
           static_cast<char>(term_attr::NORMAL + '0'),
           static_cast<char>(term_color::ORIGINAL + '0'),


### PR DESCRIPTION
Apple Clang 14 warns that `sprintf` is deprecated. Replace with the new `boost::core::snprintf` for compatibility with pre-c++11 code, and across toolchains.