### PR TITLE
fix: exception during startup

### DIFF
--- a/include/boost/test/impl/test_tree.ipp
+++ b/include/boost/test/impl/test_tree.ipp
@@ -435,7 +435,7 @@ namespace ut_detail {
 std::string
 normalize_test_case_name( const_string name )
 {
-    std::string norm_name( name.begin(), name.size() );
+    std::string norm_name( name.begin(), name.end() );
 
     if( name[0] == '&' )
         norm_name = norm_name.substr( 1 );


### PR DESCRIPTION
On my machine with windows 10 and the latest version of visual studio I get an exception during startup. The reason is that normalize_test_case_name() creates an ill-formed string object. The provided change in line 438 fixes the problem.