### PR TITLE
Fix MSVC compiler warning

### DIFF
--- a/include/boost/test/data/monomorphic/grid.hpp
+++ b/include/boost/test/data/monomorphic/grid.hpp
@@ -56,7 +56,7 @@ public:
         // Constructor
         explicit    iterator( dataset1_iter iter1, DataSet2 const& ds2 )
         : m_iter1( std::move( iter1 ) )
-        , m_iter2( std::move( ds2.begin() ) )
+        , m_iter2( ds2.begin() )
         , m_ds2( &ds2 )
         , m_ds2_pos( 0 )
         {}


### PR DESCRIPTION
Remove `std::move` on a temporary object to fix the following level 4 warning with Visual Studio 17.4 and later:

warning C5263: calling 'std::move' on a temporary object prevents copy elision