### PR TITLE
fix unreachable return compilation error

### DIFF
--- a/include/boost/test/detail/config.hpp
+++ b/include/boost/test/detail/config.hpp
@@ -151,7 +151,8 @@ class type_info;
 #endif /* ifndef BOOST_PP_VARIADICS */
 
 // some versions of VC exibit a manifest error with this BOOST_UNREACHABLE_RETURN
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1910)
+// gcc <= 4.6 fails with unused variable even when the return is never reached 
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1910) || (defined(BOOST_GCC) && BOOST_GCC < 40700)
 # define BOOST_TEST_UNREACHABLE_RETURN(x) return x
 #else
 # define BOOST_TEST_UNREACHABLE_RETURN(x) BOOST_UNREACHABLE_RETURN(x)

--- a/include/boost/test/utils/named_params.hpp
+++ b/include/boost/test/utils/named_params.hpp
@@ -131,11 +131,11 @@ struct nil {
 #else
     operator T const&() const
 #endif
-    { nfp_detail::report_access_to_invalid_parameter(true); static T* v = 0; return *v; }
+    { nfp_detail::report_access_to_invalid_parameter(true); static T* v = 0; BOOST_TEST_UNREACHABLE_RETURN(*v); }
 
     template<typename T>
     T any_cast() const
-    { nfp_detail::report_access_to_invalid_parameter(true); static typename remove_reference<T>::type* v = 0; return *v; }
+    { nfp_detail::report_access_to_invalid_parameter(true); static typename remove_reference<T>::type* v = 0; BOOST_TEST_UNREACHABLE_RETURN(*v); }
 
     template<typename Arg1>
     nil operator()( Arg1 const& )


### PR DESCRIPTION
On Visual Studio 16.9, the return was marked as unreachable because of the throw before