### PR TITLE
Include negated assertion_result messages:

### DIFF
--- a/include/boost/test/tools/assertion_result.hpp
+++ b/include/boost/test/tools/assertion_result.hpp
@@ -57,7 +57,12 @@ public:
     assertion_result( BoolConvertable const& pv_ ) : p_predicate_value( !!pv_ ) {}
 
     // Access methods
-    bool                operator!() const           { return !p_predicate_value; }
+    assertion_result    operator!() const
+    {
+        assertion_result negatedResult = !p_predicate_value;
+        negatedResult.message() << "NOT(" << ( !m_message ? std::string() : m_message->str() ) << ")";
+        return negatedResult;
+    }
     void                operator=( bool pv_ )       { p_predicate_value.value = pv_; }
     operator            safe_bool() const           { return !!p_predicate_value ? &dummy::nonnull : 0; }
 
@@ -74,6 +79,12 @@ public:
         return *m_message;
     }
     const_string        message() const                   { return !m_message ? const_string() : const_string( m_message->str() ); }
+
+    // Operators
+    friend bool operator==(bool left, const assertion_result& right) { return left == static_cast<bool>(right); }
+    friend bool operator==(const assertion_result& left, bool right) { return static_cast<bool>(left) == right; }
+    friend bool operator!=(bool left, const assertion_result& right) { return left == static_cast<bool>(right); }
+    friend bool operator!=(const assertion_result& left, bool right) { return static_cast<bool>(left) == right; }
 
 private:
     // Data members

--- a/test/writing-test-ts/assertion-construction-test.cpp
+++ b/test/writing-test-ts/assertion-construction-test.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/noncopyable.hpp>
 
+#include <locale>
 #include <map>
 #include <set>
 
@@ -405,6 +406,15 @@ public:
     }
 };
 
+boost::test_tools::predicate_result isEqualCaseInsensitive(char left, char right)
+{
+    boost::test_tools::predicate_result result(
+        std::tolower(left, std::locale::classic()) == std::tolower(right, std::locale::classic()));
+    result.message() << "[" << left << " isEqualCaseInsensitiveTo " << right << ']';
+    return result;
+}
+
+
 BOOST_AUTO_TEST_CASE( test_objects )
 {
     using namespace boost::test_tools;
@@ -468,6 +478,27 @@ BOOST_AUTO_TEST_CASE( test_objects )
         predicate_result const& res = EXPR_TYPE( nc1 == nc2 ).evaluate();
         BOOST_TEST( !res );
         BOOST_TEST( res.message() == " [NC != NC]" );
+    }
+
+    {
+        predicate_result const& res = EXPR_TYPE( isEqualCaseInsensitive('z', 'Z') ).evaluate();
+        BOOST_TEST( res );
+        BOOST_TEST( res.message() == "[z isEqualCaseInsensitiveTo Z]" );
+    }
+
+    {
+        predicate_result const& res = !EXPR_TYPE( isEqualCaseInsensitive('z', 'Z') ).evaluate();
+        BOOST_TEST( !res );
+        BOOST_TEST( res.message() == "NOT([z isEqualCaseInsensitiveTo Z])" );
+    }
+
+    {
+        NC nc1;
+        NC nc2;
+
+        predicate_result const& res = !EXPR_TYPE( nc1 == nc2 ).evaluate();
+        BOOST_TEST( res );
+        BOOST_TEST( res.message() == "NOT( [NC != NC])" );
     }
 }
 


### PR DESCRIPTION
Given a helper function `isEqualCaseInsensitive()` returning helpful detail in the `assertion_result` message, negation in a `BOOST_CHECK()` results in that detail being discarded.

This feature preserves that detail in the negated case.

For example:

`BOOST_CHECK(isEqualCaseInsensitive('z', 'Z'))` included detail like `[z isEqualCaseInsensitiveTo Z]`

`BOOST_CHECK(!isEqualCaseInsensitive('z', 'Z'))` discarded that detail until this revision, which now includes it: `NOT([z isEqualCaseInsensitiveTo Z])`