### PR TITLE
Prevent potential integer overflow in precision calculation.

### DIFF
--- a/include/boost/test/tools/detail/print_helper.hpp
+++ b/include/boost/test/tools/detail/print_helper.hpp
@@ -97,7 +97,9 @@ struct print_log_value {
     std::streamsize set_precision( std::ostream& ostr, mpl::false_ )
     {
         if( std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::radix == 2 )
-            return ostr.precision( 2 + std::numeric_limits<T>::digits * 301/1000 );
+            return ostr.precision( (std::numeric_limits<T>::digits <= std::numeric_limits<int>::max()/301 ?
+                                          2 + std::numeric_limits<T>::digits * 301/1000
+                                        : std::numeric_limits<T>::digits / 3) );
         else if ( std::numeric_limits<T>::is_specialized && std::numeric_limits<T>::radix == 10 ) {
 #ifdef BOOST_NO_CXX11_NUMERIC_LIMITS
             // (was BOOST_NO_NUMERIC_LIMITS_LOWEST but now deprecated).


### PR DESCRIPTION
This changes the precision calculation in print_helper so that the current approximation is used if the number of digits is such that no integer overflow can occur in the multiplication and a cruder approximation that cannot overflow is used otherwise. As far as I can see this shouldn't change anything for built-in and other reasonably small types. My motivation for this change is an integer overflow warning in the Boost.Geometry test suite for a test with a Boost.Multiprecision type.

Note that, if I read 3.1 in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n2005.pdf right, the 301/1000 approximation of log(2) might be insufficient for types with more 265 digits. If this is considered relevant for the use case of this code and warrants the additional complexity, I can change this PR to account for that.