### PR TITLE
fix <boost/test/unit_test.hpp> - remove the requirement to define BOOST_TEST_MAIN to get auto-link

### DIFF
--- a/include/boost/test/unit_test.hpp
+++ b/include/boost/test/unit_test.hpp
@@ -25,8 +25,7 @@
 // ************************************************************************** //
 
 #if !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_TEST_NO_LIB) && \
-    !defined(BOOST_TEST_SOURCE) && !defined(BOOST_TEST_INCLUDED) && \
-    defined(BOOST_TEST_MAIN)
+    !defined(BOOST_TEST_SOURCE) && !defined(BOOST_TEST_INCLUDED)
 #  define BOOST_LIB_NAME boost_unit_test_framework
 
 #  if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_TEST_DYN_LINK)


### PR DESCRIPTION
This requirement coming from commit 961646222e4cf0eb475a86667a71ce89e4994d5c is obvious bug, because if user defines `BOOST_TEST_MAIN`, then boost defines `init_unit_test_suite` in `<boost/test/unit_test_suite.hpp>`, which conflicts with user's custom definition of `init_unit_test_suite`.

(It's interesting however that it got "past radar" for 3+ years.)