### PR TITLE
fix "boost/test/impl/execution_monitor.ipp" compilation in GCC 13.2

### DIFF
--- a/include/boost/test/impl/execution_monitor.ipp
+++ b/include/boost/test/impl/execution_monitor.ipp
@@ -202,7 +202,7 @@ namespace { void _set_se_translator( void* ) {} }
 #      define BOOST_TEST_DEFINED_STDC_FORMAT_MACROS
 #    endif
 #  endif
-#  include <inttypes.h>
+#  include <cinttypes>
 #  define BOOST_TEST_PRIxPTR PRIxPTR
 #  ifdef BOOST_TEST_DEFINED_STDC_FORMAT_MACROS
 #    undef __STDC_FORMAT_MACROS


### PR DESCRIPTION
Without this fix GCC was giving compile error that PRIxPTR is not defined.