### PR TITLE
Add support for modular build structure.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,13 @@ jobs:
             install:
               - g++-12-multilib
           - name: UBSAN
-            toolset: gcc-12
-            cxxstd: "17"
+            toolset: gcc-13
+            cxxstd: "11"
             address_model: 64
             ubsan: 1
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             install:
-              - g++-12-multilib
+              - g++-13-multilib
 
           # Linux, clang
           - toolset: clang

--- a/Jamfile.v2
+++ b/Jamfile.v2
@@ -1,9 +1,0 @@
-#  (C) Copyright Juergen Hunold 2006-2010.
-#  Use, modification, and distribution are subject to the
-#  Boost Software License, Version 1.0. (See accompanying file
-#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-#
-#  See http://www.boost.org/libs/test for the library home page.
-
-build-project example ;
-build-project test ;

--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,56 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/test
+    : common-requirements
+        <source>/boost/algorithm//boost_algorithm
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/exception//boost_exception
+        <source>/boost/function//boost_function
+        <source>/boost/io//boost_io
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/numeric_conversion//boost_numeric_conversion
+        <source>/boost/optional//boost_optional
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_test ]
+    [ alias boost_prg_exec_monitor : build//boost_prg_exec_monitor ]
+    [ alias boost_test_exec_monitor : build//boost_test_exec_monitor ]
+    [ alias boost_unit_test_framework : build//boost_unit_test_framework ]
+    [ alias prg_exec_monitor : boost_prg_exec_monitor ]
+    [ alias test_exec_monitor : boost_test_exec_monitor ]
+    [ alias unit_test_framework : boost_unit_test_framework ]
+    [ alias boost_included_prg_exec_monitor ]
+    [ alias boost_included_test_exec_monitor ]
+    [ alias boost_included_unit_test_framework ]
+    [ alias included_prg_exec_monitor : boost_included_prg_exec_monitor ]
+    [ alias included_test_exec_monitor : boost_included_test_exec_monitor ]
+    [ alias included_unit_test_framework : boost_included_unit_test_framework ]
+    [ alias all : example test
+        boost_prg_exec_monitor
+        boost_test_exec_monitor
+        boost_unit_test_framework ]
+    ;
+
+call-if : boost-library test
+    : install
+        boost_prg_exec_monitor
+        boost_test_exec_monitor
+        boost_unit_test_framework
+    ;

--- a/build.jam
+++ b/build.jam
@@ -41,6 +41,7 @@ explicit
     [ alias boost_included_prg_exec_monitor : : : : <library>$(boost_dependencies) ]
     [ alias boost_included_test_exec_monitor : : : : <library>$(boost_dependencies) ]
     [ alias boost_included_unit_test_framework : : : : <library>$(boost_dependencies) ]
+    [ alias included : : : : <library>$(boost_dependencies) ]
     [ alias included_prg_exec_monitor : boost_included_prg_exec_monitor ]
     [ alias included_test_exec_monitor : boost_included_test_exec_monitor ]
     [ alias included_unit_test_framework : boost_included_unit_test_framework ]

--- a/build.jam
+++ b/build.jam
@@ -7,24 +7,24 @@ import project ;
 
 project /boost/test
     : common-requirements
-        <source>/boost/algorithm//boost_algorithm
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/exception//boost_exception
-        <source>/boost/function//boost_function
-        <source>/boost/io//boost_io
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/numeric_conversion//boost_numeric_conversion
-        <source>/boost/optional//boost_optional
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/algorithm//boost_algorithm
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/exception//boost_exception
+        <library>/boost/function//boost_function
+        <library>/boost/io//boost_io
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/numeric_conversion//boost_numeric_conversion
+        <library>/boost/optional//boost_optional
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,40 +5,42 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/algorithm//boost_algorithm
+    /boost/assert//boost_assert
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/exception//boost_exception
+    /boost/function//boost_function
+    /boost/io//boost_io
+    /boost/iterator//boost_iterator
+    /boost/mpl//boost_mpl
+    /boost/numeric_conversion//boost_numeric_conversion
+    /boost/optional//boost_optional
+    /boost/preprocessor//boost_preprocessor
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/test
     : common-requirements
-        <library>/boost/algorithm//boost_algorithm
-        <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/exception//boost_exception
-        <library>/boost/function//boost_function
-        <library>/boost/io//boost_io
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/numeric_conversion//boost_numeric_conversion
-        <library>/boost/optional//boost_optional
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_test ]
+    [ alias boost_test : : : : <library>$(boost_dependencies) ]
     [ alias boost_prg_exec_monitor : build//boost_prg_exec_monitor ]
     [ alias boost_test_exec_monitor : build//boost_test_exec_monitor ]
     [ alias boost_unit_test_framework : build//boost_unit_test_framework ]
     [ alias prg_exec_monitor : boost_prg_exec_monitor ]
     [ alias test_exec_monitor : boost_test_exec_monitor ]
     [ alias unit_test_framework : boost_unit_test_framework ]
-    [ alias boost_included_prg_exec_monitor ]
-    [ alias boost_included_test_exec_monitor ]
-    [ alias boost_included_unit_test_framework ]
+    [ alias boost_included_prg_exec_monitor : : : : <library>$(boost_dependencies) ]
+    [ alias boost_included_test_exec_monitor : : : : <library>$(boost_dependencies) ]
+    [ alias boost_included_unit_test_framework : : : : <library>$(boost_dependencies) ]
     [ alias included_prg_exec_monitor : boost_included_prg_exec_monitor ]
     [ alias included_test_exec_monitor : boost_included_test_exec_monitor ]
     [ alias included_unit_test_framework : boost_included_unit_test_framework ]
@@ -54,3 +56,4 @@ call-if : boost-library test
         boost_test_exec_monitor
         boost_unit_test_framework
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/test
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/test

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,6 +12,7 @@ import predef
 
 project
     : source-location ../src
+    : common-requirements <library>$(boost_dependencies)
     : requirements <link>shared:<define>BOOST_TEST_DYN_LINK=1
                    <toolset>borland:<cxxflags>-w-8080
                    <target-os>cygwin:<define>_POSIX_C_SOURCE=200112L

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,6 +6,7 @@
 
 import os ;
 
+import-search /boost/predef/tools/check ;
 import predef
     : check
     : predef-check ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -26,7 +26,7 @@ project
                    # <warnings-as-errors>on
 
     : usage-requirements
-                   <define>BOOST_TEST_NO_AUTO_LINK=1
+                   <define>BOOST_TEST_NO_LIB=1
                    # Disable Warning about boost::noncopyable not being exported
                    <link>shared,<toolset>msvc:<cxxflags>-wd4275
     ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,11 +6,11 @@
 
 import os ;
 
-import ../../predef/check/predef
+import predef
     : check
     : predef-check ;
 
-project boost/test
+project
     : source-location ../src
     : requirements <link>shared:<define>BOOST_TEST_DYN_LINK=1
                    <toolset>borland:<cxxflags>-w-8080
@@ -113,7 +113,3 @@ lib boost_unit_test_framework
 alias minimal ;
 
 alias included ;
-
-boost-install boost_prg_exec_monitor
-              boost_test_exec_monitor
-              boost_unit_test_framework ;

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -14,80 +14,82 @@ using boostbook ;
 
 import doxygen ;
 
+path-constant TEST_ROOT : .. ;
+
 doxygen doxygen_reference_generated_doc
     :
-      $(BOOST_ROOT)/libs/test/include/boost/test/debug_config.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/detail/global_typedef.hpp      
-      $(BOOST_ROOT)/libs/test/include/boost/test/debug.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/execution_monitor.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/framework.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/assertion_result.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/unit_test.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tree/observer.hpp
+      $(TEST_ROOT)/include/boost/test/debug_config.hpp
+      $(TEST_ROOT)/include/boost/test/detail/global_typedef.hpp
+      $(TEST_ROOT)/include/boost/test/debug.hpp
+      $(TEST_ROOT)/include/boost/test/execution_monitor.hpp
+      $(TEST_ROOT)/include/boost/test/framework.hpp
+      $(TEST_ROOT)/include/boost/test/tools/assertion_result.hpp
+      $(TEST_ROOT)/include/boost/test/unit_test.hpp
+      $(TEST_ROOT)/include/boost/test/tree/observer.hpp
 
       # logs and formatters
-      $(BOOST_ROOT)/libs/test/include/boost/test/unit_test_log.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/output/xml_log_formatter.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/output/plain_report_formatter.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/output/compiler_log_formatter.hpp
+      $(TEST_ROOT)/include/boost/test/unit_test_log.hpp
+      $(TEST_ROOT)/include/boost/test/output/xml_log_formatter.hpp
+      $(TEST_ROOT)/include/boost/test/output/plain_report_formatter.hpp
+      $(TEST_ROOT)/include/boost/test/output/compiler_log_formatter.hpp
 
       # reports
-      $(BOOST_ROOT)/libs/test/include/boost/test/output/xml_report_formatter.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/unit_test_log_formatter.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/results_reporter.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/results_collector.hpp
+      $(TEST_ROOT)/include/boost/test/output/xml_report_formatter.hpp
+      $(TEST_ROOT)/include/boost/test/unit_test_log_formatter.hpp
+      $(TEST_ROOT)/include/boost/test/results_reporter.hpp
+      $(TEST_ROOT)/include/boost/test/results_collector.hpp
 
       # progress monitor
-      $(BOOST_ROOT)/libs/test/include/boost/test/progress_monitor.hpp
+      $(TEST_ROOT)/include/boost/test/progress_monitor.hpp
 
       # test cases and suites
-      $(BOOST_ROOT)/libs/test/include/boost/test/tree/test_unit.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/parameterized_test.hpp
+      $(TEST_ROOT)/include/boost/test/tree/test_unit.hpp
+      $(TEST_ROOT)/include/boost/test/parameterized_test.hpp
 
       # execution monitor source files
-      $(BOOST_ROOT)/libs/test/include/boost/test/execution_monitor.hpp
+      $(TEST_ROOT)/include/boost/test/execution_monitor.hpp
 
       # output test stream
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/output_test_stream.hpp
+      $(TEST_ROOT)/include/boost/test/tools/output_test_stream.hpp
 
       # datasets
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/fwd.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/test_case.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/for_each_sample.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/size.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/delayed.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/initializer_list.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/array.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/collection.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/generate.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/fwd.hpp
+      $(TEST_ROOT)/include/boost/test/data/test_case.hpp
+      $(TEST_ROOT)/include/boost/test/data/for_each_sample.hpp
+      $(TEST_ROOT)/include/boost/test/data/size.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/delayed.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/initializer_list.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/array.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/collection.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/generate.hpp
 
 
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/grid.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/join.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/singleton.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/zip.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/grid.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/join.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/singleton.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/zip.hpp
 
       # datasets generators
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/config.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/generators.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/generators/keywords.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/generators/random.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/data/monomorphic/generators/xrange.hpp
+      $(TEST_ROOT)/include/boost/test/data/config.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/generators.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/generators/keywords.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/generators/random.hpp
+      $(TEST_ROOT)/include/boost/test/data/monomorphic/generators/xrange.hpp
 
       # utils
-      $(BOOST_ROOT)/libs/test/include/boost/test/utils/algorithm.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/utils/named_params.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/floating_point_comparison.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/utils/is_forward_iterable.hpp
+      $(TEST_ROOT)/include/boost/test/utils/algorithm.hpp
+      $(TEST_ROOT)/include/boost/test/utils/named_params.hpp
+      $(TEST_ROOT)/include/boost/test/tools/floating_point_comparison.hpp
+      $(TEST_ROOT)/include/boost/test/utils/is_forward_iterable.hpp
 
       # BOOST_TEST related functions
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/detail/bitwise_manip.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/detail/lexicographic_manip.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/detail/per_element_manip.hpp
-      $(BOOST_ROOT)/libs/test/include/boost/test/tools/detail/tolerance_manip.hpp
+      $(TEST_ROOT)/include/boost/test/tools/detail/bitwise_manip.hpp
+      $(TEST_ROOT)/include/boost/test/tools/detail/lexicographic_manip.hpp
+      $(TEST_ROOT)/include/boost/test/tools/detail/per_element_manip.hpp
+      $(TEST_ROOT)/include/boost/test/tools/detail/tolerance_manip.hpp
 
       # others
-      $(BOOST_ROOT)/libs/test/include/boost/test/unit_test_parameters.hpp
+      $(TEST_ROOT)/include/boost/test/unit_test_parameters.hpp
     :
         <doxygen:param>EXTRACT_ALL=YES
         <doxygen:param>"PREDEFINED=\"BOOST_TEST_DECL=\" \\
@@ -102,8 +104,8 @@ doxygen doxygen_reference_generated_doc
         <doxygen:param>MACRO_EXPANSION=YES
         <doxygen:param>EXPAND_ONLY_PREDEF=YES
         <doxygen:param>SEARCH_INCLUDES=YES
-        <doxygen:param>INCLUDE_PATH=$(BOOST_ROOT)/libs/test/include
-        <doxygen:param>EXAMPLE_PATH=$(BOOST_ROOT)/libs/test/doc/examples
+        <doxygen:param>INCLUDE_PATH=$(TEST_ROOT)/include
+        <doxygen:param>EXAMPLE_PATH=$(TEST_ROOT)/doc/examples
         <doxygen:param>BRIEF_MEMBER_DESC=YES
         <doxygen:param>REPEAT_BRIEF=YES
         <doxygen:param>ALWAYS_DETAILED_SEC=YES

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -61,7 +61,7 @@ alias boost_test_examples
     [ run      unit_test_example_08.cpp unit_test_framework ]
     [ run      unit_test_example_09_1.cpp
                unit_test_example_09_2.cpp unit_test_framework ]
-    [ run-fail unit_test_example_10.cpp unit_test_framework/<link>static : : : <source>/boost/lexical_cast//boost_lexical_cast ]
+    [ run-fail unit_test_example_10.cpp unit_test_framework/<link>static : : : <library>/boost/lexical_cast//boost_lexical_cast ]
     [ run-fail unit_test_example_11.cpp unit_test_framework/<link>static ]
     [ link     unit_test_example_12.cpp unit_test_framework/<link>static ]
     [ run      unit_test_example_13.cpp ]

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -11,7 +11,7 @@ import testing ;
 import os ;
 
 # requirements
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 local HAS_UBSAN = "NO_UBSAN" ; # need to defined something
 if [ os.environ UBSAN ]
@@ -22,7 +22,7 @@ if [ os.environ UBSAN ]
 ECHO $(HAS_UBSAN:J) ;
 
 # Project
-project boost/test-examples
+project
     :
     : requirements
       <toolset>clang:<cxxflags>-Wno-c99-extensions <define>$(HAS_UBSAN:J)
@@ -31,12 +31,12 @@ project boost/test-examples
 # Define aliases for the needed libs to get shorter names
 alias prg_exec_monitor
     : # sources
-        /boost//prg_exec_monitor
+        /boost/test//boost_prg_exec_monitor
     ;
 
 alias unit_test_framework
     : # sources
-        /boost//unit_test_framework
+        /boost/test//boost_unit_test_framework
     ;
 
 # make aliases explicit so the libraries will only be built when requested
@@ -60,7 +60,7 @@ alias boost_test_examples
     [ run      unit_test_example_08.cpp unit_test_framework ]
     [ run      unit_test_example_09_1.cpp
                unit_test_example_09_2.cpp unit_test_framework ]
-    [ run-fail unit_test_example_10.cpp unit_test_framework/<link>static ]
+    [ run-fail unit_test_example_10.cpp unit_test_framework/<link>static : : : <source>/boost/lexical_cast//boost_lexical_cast ]
     [ run-fail unit_test_example_11.cpp unit_test_framework/<link>static ]
     [ link     unit_test_example_12.cpp unit_test_framework/<link>static ]
     [ run      unit_test_example_13.cpp ]

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -26,6 +26,7 @@ ECHO $(HAS_UBSAN:J) ;
 project
     :
     : requirements
+      <library>/boost/test//boost_test
       <toolset>clang:<cxxflags>-Wno-c99-extensions <define>$(HAS_UBSAN:J)
     ;
 

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -11,6 +11,7 @@ import testing ;
 import os ;
 
 # requirements
+import-search /boost/config/checks ;
 import config : requires ;
 
 local HAS_UBSAN = "NO_UBSAN" ; # need to defined something

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@ project
     : requirements
     ;
 
+import-search /boost/predef/tools/check ;
 import predef
     : check require
     : predef-check predef-require ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -102,7 +102,7 @@ rule docs-example-as-test ( test-file )
               :
               :
               : $(requirements_documentation) # requirements
-                <source>/boost/rational//boost_rational
+                <library>/boost/rational//boost_rational
             ] ;
 }
 
@@ -142,11 +142,11 @@ test-suite "usage-variants-ts"
 
 test-suite "framework-ts"
 :
-  # [ boost.test-self-test run : framework-ts : result-report-test : : baseline-outputs/result-report-test.pattern baseline-outputs/result_report_test.pattern.default_behaviour : : : : <source>/boost/lexical_cast//boost_lexical_cast ]
-  [ boost.test-self-test run : framework-ts : log-formatter-test : : baseline-outputs/log-formatter-context-test.pattern baseline-outputs/log-formatter-test.pattern baseline-outputs/log-formatter-test.pattern.junit : : : : <source>/boost/lexical_cast//boost_lexical_cast ] # should be ordered alphabetically
+  # [ boost.test-self-test run : framework-ts : result-report-test : : baseline-outputs/result-report-test.pattern baseline-outputs/result_report_test.pattern.default_behaviour : : : : <library>/boost/lexical_cast//boost_lexical_cast ]
+  [ boost.test-self-test run : framework-ts : log-formatter-test : : baseline-outputs/log-formatter-context-test.pattern baseline-outputs/log-formatter-test.pattern baseline-outputs/log-formatter-test.pattern.junit : : : : <library>/boost/lexical_cast//boost_lexical_cast ] # should be ordered alphabetically
   [ boost.test-self-test run : framework-ts : run-by-name-or-label-test ]
   [ boost.test-self-test run : framework-ts : version-uses-module-name : included ]
-  [ boost.test-self-test run : framework-ts : test-macro-global-fixture : : baseline-outputs/global-fixtures-test.pattern : : : : <source>/boost/lexical_cast//boost_lexical_cast ]
+  [ boost.test-self-test run : framework-ts : test-macro-global-fixture : : baseline-outputs/global-fixtures-test.pattern : : : : <library>/boost/lexical_cast//boost_lexical_cast ]
   [ boost.test-self-test run : framework-ts : message-in-datatestcase-test : : baseline-outputs/messages-in-datasets-test.pattern : : : : $(requirements_datasets) ]
   [ boost.test-self-test run : framework-ts : decorators-datatestcase-test : : : : : : $(requirements_datasets) ]
   [ compile-fail framework-ts/master-test-suite-non-copyable-test.cpp ../build//included ]
@@ -167,7 +167,7 @@ test-suite "writing-test-ts"
   [ boost.test-self-test run : writing-test-ts : collection-comparison-test : : : : : : $(requirements_boost_test_full_support)  [ requires cxx11_unified_initialization_syntax ] ] # required by the test content
   [ boost.test-self-test run : writing-test-ts : dont_print_log_value-test : : : : : : $(requirements_datasets) ]
   [ boost.test-self-test run : writing-test-ts : fp-comparisons-test : : : : : : $(requirements_boost_test_full_support) ]
-  [ boost.test-self-test run : writing-test-ts : fp-multiprecision-comparison-test : : : : : : $(requirements_boost_test_full_support) [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] <source>/boost/multiprecision//boost_multiprecision ]
+  [ boost.test-self-test run : writing-test-ts : fp-multiprecision-comparison-test : : : : : : $(requirements_boost_test_full_support) [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] <library>/boost/multiprecision//boost_multiprecision ]
   [ boost.test-self-test run : writing-test-ts : fp-no-comparison-for-incomplete-types-test ]
   [ boost.test-self-test run : writing-test-ts : fp-relational-operator ]
   [ boost.test-self-test run : writing-test-ts : output_test_stream-test ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -16,6 +16,7 @@ import config : requires ;
 
 project
     : requirements
+        <library>/boost/test//boost_test
     ;
 
 import-search /boost/predef/tools/check ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -12,13 +12,13 @@ import property-set ;
 import regex ;
 import "class" : new ;
 
-import ../../config/checks/config : requires ;
+import config : requires ;
 
-project boost/test-tests
+project
     : requirements
     ;
 
-import ../../predef/check/predef
+import predef
     : check require
     : predef-check predef-require ;
 
@@ -102,6 +102,7 @@ rule docs-example-as-test ( test-file )
               :
               :
               : $(requirements_documentation) # requirements
+                <source>/boost/rational//boost_rational
             ] ;
 }
 
@@ -141,11 +142,11 @@ test-suite "usage-variants-ts"
 
 test-suite "framework-ts"
 :
-  # [ boost.test-self-test run : framework-ts : result-report-test : : baseline-outputs/result-report-test.pattern baseline-outputs/result_report_test.pattern.default_behaviour ]
-  [ boost.test-self-test run : framework-ts : log-formatter-test : : baseline-outputs/log-formatter-context-test.pattern baseline-outputs/log-formatter-test.pattern baseline-outputs/log-formatter-test.pattern.junit ] # should be ordered alphabetically
+  # [ boost.test-self-test run : framework-ts : result-report-test : : baseline-outputs/result-report-test.pattern baseline-outputs/result_report_test.pattern.default_behaviour : : : : <source>/boost/lexical_cast//boost_lexical_cast ]
+  [ boost.test-self-test run : framework-ts : log-formatter-test : : baseline-outputs/log-formatter-context-test.pattern baseline-outputs/log-formatter-test.pattern baseline-outputs/log-formatter-test.pattern.junit : : : : <source>/boost/lexical_cast//boost_lexical_cast ] # should be ordered alphabetically
   [ boost.test-self-test run : framework-ts : run-by-name-or-label-test ]
   [ boost.test-self-test run : framework-ts : version-uses-module-name : included ]
-  [ boost.test-self-test run : framework-ts : test-macro-global-fixture : : baseline-outputs/global-fixtures-test.pattern ]
+  [ boost.test-self-test run : framework-ts : test-macro-global-fixture : : baseline-outputs/global-fixtures-test.pattern : : : : <source>/boost/lexical_cast//boost_lexical_cast ]
   [ boost.test-self-test run : framework-ts : message-in-datatestcase-test : : baseline-outputs/messages-in-datasets-test.pattern : : : : $(requirements_datasets) ]
   [ boost.test-self-test run : framework-ts : decorators-datatestcase-test : : : : : : $(requirements_datasets) ]
   [ compile-fail framework-ts/master-test-suite-non-copyable-test.cpp ../build//included ]
@@ -166,7 +167,7 @@ test-suite "writing-test-ts"
   [ boost.test-self-test run : writing-test-ts : collection-comparison-test : : : : : : $(requirements_boost_test_full_support)  [ requires cxx11_unified_initialization_syntax ] ] # required by the test content
   [ boost.test-self-test run : writing-test-ts : dont_print_log_value-test : : : : : : $(requirements_datasets) ]
   [ boost.test-self-test run : writing-test-ts : fp-comparisons-test : : : : : : $(requirements_boost_test_full_support) ]
-  [ boost.test-self-test run : writing-test-ts : fp-multiprecision-comparison-test : : : : : : $(requirements_boost_test_full_support) [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] ]
+  [ boost.test-self-test run : writing-test-ts : fp-multiprecision-comparison-test : : : : : : $(requirements_boost_test_full_support) [ requires cxx14_decltype_auto cxx14_generic_lambdas cxx14_return_type_deduction cxx14_variable_templates cxx14_constexpr ] <source>/boost/multiprecision//boost_multiprecision ]
   [ boost.test-self-test run : writing-test-ts : fp-no-comparison-for-incomplete-types-test ]
   [ boost.test-self-test run : writing-test-ts : fp-relational-operator ]
   [ boost.test-self-test run : writing-test-ts : output_test_stream-test ]
@@ -336,19 +337,19 @@ rule boost.test-smoke-ts-logger ( test-name-prefix : logger ? : log_or_report ? 
    return $(to-return) ;
 }
 
-exe smoke-ts-included : smoke-ts/basic-smoke-test.cpp
+alias smoke-ts-included : smoke-ts/basic-smoke-test.cpp
                       : $(requirements_datasets) ;
 
-exe smoke-ts-included-2 : smoke-ts/basic-smoke-test2.cpp ;
+alias smoke-ts-included-2 : smoke-ts/basic-smoke-test2.cpp ;
 
-exe smoke-ts-included-3 : smoke-ts/basic-smoke-test3.cpp ;
+alias smoke-ts-included-3 : smoke-ts/basic-smoke-test3.cpp ;
 
 # for template test case filtering from the command line
-exe smoke-ts-included-4 : smoke-ts/basic-smoke-test4.cpp ;
+alias smoke-ts-included-4 : smoke-ts/basic-smoke-test4.cpp ;
 
-exe check-streams-on-exit : framework-ts/check-streams-on-exit.cpp ;
+alias check-streams-on-exit : framework-ts/check-streams-on-exit.cpp ;
 
-exe dataset-master-test-suite-accessible-test : test-organization-ts/dataset-master-test-suite-accessible-test.cpp
+alias dataset-master-test-suite-accessible-test : test-organization-ts/dataset-master-test-suite-accessible-test.cpp
                                               : $(requirements_datasets) ;
 
 alias "smoke-ts"
@@ -434,12 +435,12 @@ alias "smoke-ts"
 [ run smoke-ts-included-4 : \"--run_test=some_suite/test<my_struct<float_ float>>,test<my_struct<char_ char>>\" \"--run_test=test<my_struct<int_ int>>\" : : : cla-template-test-case-sanity-15 ]
 ;
 
-exe custom-command-line-binary-1 : ../doc/examples/runtime-configuration_1.run-fail.cpp ;
-exe custom-command-line-binary-2 : ../doc/examples/runtime-configuration_2.run-fail.cpp
+alias custom-command-line-binary-1 : ../doc/examples/runtime-configuration_1.run-fail.cpp ;
+alias custom-command-line-binary-2 : ../doc/examples/runtime-configuration_2.run-fail.cpp
                                  : $(requirements_boost_test_full_support) ;
-exe custom-command-line-binary-3 : ../doc/examples/runtime-configuration_3.run-fail.cpp
+alias custom-command-line-binary-3 : ../doc/examples/runtime-configuration_3.run-fail.cpp
                                  : $(requirements_boost_test_full_support) ;
-exe custom-command-line-binary-4 : ../doc/examples/runtime-configuration_4.run-fail.cpp
+alias custom-command-line-binary-4 : ../doc/examples/runtime-configuration_4.run-fail.cpp
                                  : $(requirements_datasets) [ requires cxx11_trailing_result_types cxx11_auto_declarations ] $(l_gcc_c11_rvalue_full_support) ;
 
 alias "custom-command-line-ts"

--- a/tools/console_test_runner/Jamfile.v2
+++ b/tools/console_test_runner/Jamfile.v2
@@ -1,6 +1,6 @@
 #  (C) Copyright Gennadiy Rozental 2008-2014.
-#  Use, modification, and distribution are subject to the 
-#  Boost Software License, Version 1.0. (See accompanying file 
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 #  See http://www.boost.org/libs/test for the library home page.
@@ -10,29 +10,29 @@ project libs/test/tools/console_test_runner ;
 
 alias unit_test_framework
     : # sources
-        /boost//unit_test_framework
-    ;        
+        /boost/test//boost_unit_test_framework
+    ;
 
 alias test_runner_src
     : # sources
       src/console_test_runner.cpp
-      unit_test_framework  
-    ;        
+      unit_test_framework
+    ;
 
 # make aliases explicit so the libraries will only be built when requested
 explicit unit_test_framework ;
 explicit test_runner_src ;
 
-lib dl ; 
+lib dl ;
 
-lib test_runner_test : test/test_runner_test.cpp unit_test_framework ; 
+lib test_runner_test : test/test_runner_test.cpp unit_test_framework ;
 
-exe console_test_runner 
+exe console_test_runner
     : test_runner_src
-      dl 
+      dl
     ;
 
-exe console_test_runner 
+exe console_test_runner
     : test_runner_src
     : <target-os>windows
     ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.