### PR TITLE
Fix for the issue #430, arg_type_mismatch exception with dynamic link

### DIFF
--- a/example/unit_test_example_16.cpp
+++ b/example/unit_test_example_16.cpp
@@ -20,6 +20,10 @@ bool init_unit_test()
 #if (!defined(BOOST_TEST_DYN_LINK) || (!defined(BOOST_CLANG) || (BOOST_CLANG != 1) || (__clang_major__ >= 8))) && !defined(__APPLE__)
   log_level logLevel = runtime_config::get<log_level>(runtime_config::btrt_log_level);
   std::cout << "Current log level: " << static_cast<int>(logLevel) << std::endl;
+  output_format logFormat = runtime_config::get<output_format>(runtime_config::btrt_log_format);
+  std::cout << "Current log format: " << static_cast<int>(logFormat) << std::endl;
+  report_level reportLevel = runtime_config::get<report_level>(runtime_config::btrt_report_level);
+  std::cout << "Current report level: " << static_cast<int>(reportLevel) << std::endl;
 #endif
   return true;
 }

--- a/include/boost/test/detail/global_typedef.hpp
+++ b/include/boost/test/detail/global_typedef.hpp
@@ -29,17 +29,21 @@ typedef unsigned long   counter_t;
 
 //____________________________________________________________________________//
 
-enum report_level  { INV_REPORT_LEVEL, CONFIRMATION_REPORT, SHORT_REPORT, DETAILED_REPORT, NO_REPORT };
+enum BOOST_SYMBOL_VISIBLE report_level  { INV_REPORT_LEVEL,
+                                          CONFIRMATION_REPORT,
+                                          SHORT_REPORT,
+                                          DETAILED_REPORT,
+                                          NO_REPORT };
 
 //____________________________________________________________________________//
 
 //! Indicates the output format for the loggers or the test tree printing
-enum output_format { OF_INVALID,
-                     OF_CLF,      ///< compiler log format
-                     OF_XML,      ///< XML format for report and log,
-                     OF_JUNIT,    ///< JUNIT format for report and log,
-                     OF_CUSTOM_LOGGER, ///< User specified logger.
-                     OF_DOT       ///< dot format for output content
+enum BOOST_SYMBOL_VISIBLE output_format { OF_INVALID,
+                                          OF_CLF,      ///< compiler log format
+                                          OF_XML,      ///< XML format for report and log,
+                                          OF_JUNIT,    ///< JUNIT format for report and log,
+                                          OF_CUSTOM_LOGGER, ///< User specified logger.
+                                          OF_DOT       ///< dot format for output content
 };
 
 //____________________________________________________________________________//


### PR DESCRIPTION
This is the fix for https://github.com/boostorg/test/issues/430.
If the library is linked dynamically, clang built binary raises the arg_type_mismatch exception on reading configuration variables with type output_format or report_level.
I've added the test in unit_test_example_16.cpp but found that it was commented out from build and leave as it is.
