### PR TITLE
Rename method arguments to avoid collision with linux UAPI macro

### DIFF
--- a/include/boost/test/impl/test_tree.ipp
+++ b/include/boost/test/impl/test_tree.ipp
@@ -501,16 +501,16 @@ auto_test_unit_registrar::auto_test_unit_registrar( const_string ts_name, const_
 
 //____________________________________________________________________________//
 
-auto_test_unit_registrar::auto_test_unit_registrar( test_unit_generator const& tc_gen, decorator::collector_t& decorators )
+auto_test_unit_registrar::auto_test_unit_registrar( test_unit_generator const& tc_generator, decorator::collector_t& decorators )
 {
-    framework::current_auto_test_suite().add( tc_gen, decorators );
+    framework::current_auto_test_suite().add( tc_generator, decorators );
 }
 
 //____________________________________________________________________________//
 
-auto_test_unit_registrar::auto_test_unit_registrar( boost::shared_ptr<test_unit_generator> tc_gen, decorator::collector_t& decorators )
+auto_test_unit_registrar::auto_test_unit_registrar( boost::shared_ptr<test_unit_generator> tc_generator, decorator::collector_t& decorators )
 {
-    framework::current_auto_test_suite().add( tc_gen, decorators );
+    framework::current_auto_test_suite().add( tc_generator, decorators );
 }
 
 

--- a/include/boost/test/tree/auto_registration.hpp
+++ b/include/boost/test/tree/auto_registration.hpp
@@ -39,8 +39,8 @@ struct BOOST_TEST_DECL auto_test_unit_registrar {
     // Constructors
                 auto_test_unit_registrar( test_case* tc, decorator::collector_t& decorators, counter_t exp_fail = 0 );
     explicit    auto_test_unit_registrar( const_string ts_name, const_string ts_file, std::size_t ts_line, decorator::collector_t& decorators );
-    explicit    auto_test_unit_registrar( test_unit_generator const& tc_gen, decorator::collector_t& decorators );
-    explicit    auto_test_unit_registrar( boost::shared_ptr<test_unit_generator>  tc_gen, decorator::collector_t& decorators );
+    explicit    auto_test_unit_registrar( test_unit_generator const& tc_generator, decorator::collector_t& decorators );
+    explicit    auto_test_unit_registrar( boost::shared_ptr<test_unit_generator>  tc_generator, decorator::collector_t& decorators );
     explicit    auto_test_unit_registrar( int );
 };
 


### PR DESCRIPTION
`tc_gen` is a macro in the linux UAPI, if included before `<boost/test/unit_test.hpp>` it causes compilation to fail.