### PR TITLE
Include <cstddef> in <boost/test/data/size.hpp>

### DIFF
--- a/include/boost/test/data/size.hpp
+++ b/include/boost/test/data/size.hpp
@@ -17,6 +17,7 @@
 
 // STL
 #include <iosfwd>
+#include <cstddef>
 
 #include <boost/test/detail/suppress_warnings.hpp>
 


### PR DESCRIPTION
If datasets are used, `<boost/test/data/size.hpp>` is also included, as can be seen in the [example](
    https://www.boost.org/doc/libs/1_87_0/libs/test/doc/html/boost_test/tests_organization/test_cases/test_case_generation/datasets.html#boost_test.tests_organization.test_cases.test_case_generation.datasets.dataset_interface.example_descr). The class `class size_t` uses `std::size_t` in its API.
MSVC and Gcc indirectly have the definition of `std::size_t`, while Clang/LibC++ do not have this and a compiler error occurs. This fix will correct this.