### PR TITLE
cmake: Add `BOOST_TEST_HEADERS_ONLY` configuration variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,19 +76,22 @@ jobs:
           - toolset: gcc-9
             cxxstd: "17,2a"
             address_model: 64
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - g++-9-multilib
           - toolset: gcc-9
             cxxstd: "17-gnu,2a-gnu"
             address_model: 64
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - g++-9-multilib
           - toolset: gcc-10
             cxxstd: "17,20"
             address_model: 64
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - g++-10-multilib
           - toolset: gcc-11
@@ -174,13 +177,15 @@ jobs:
           - toolset: clang
             compiler: clang++-9
             cxxstd: "17,2a"
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - clang-9
           - toolset: clang
             compiler: clang++-10
             cxxstd: "17,20"
-            os: ubuntu-20.04
+            os: ubuntu-latest
+            container: ubuntu:20.04
             install:
               - clang-10
           - toolset: clang
@@ -531,8 +536,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04, build_shared: ON,  build_type: Debug, generator: 'Unix Makefiles' }
-          - { os: ubuntu-20.04, build_shared: OFF, build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: ubuntu-22.04, build_shared: ON,  build_type: Debug, generator: 'Unix Makefiles' }
+          - { os: ubuntu-22.04, build_shared: OFF, build_type: Debug, generator: 'Unix Makefiles' }
           - { os: windows-2019, build_shared: ON,  build_type: Debug, generator: 'Visual Studio 16 2019' }
           - { os: windows-2019, build_shared: OFF, build_type: Debug, generator: 'Visual Studio 16 2019' }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,64 +30,74 @@ set(_boost_test_dependencies
   Boost::utility
 )
 
-# Compiled targets
+option(BOOST_TEST_HEADERS_ONLY "Boost.Test: Only install headers" OFF)
 
-function(boost_test_add_library name)
+set(_boost_test_libraries "")
 
-  add_library(boost_${name} ${ARGN})
-  add_library(Boost::${name} ALIAS boost_${name})
+if (NOT BOOST_TEST_HEADERS_ONLY)
 
-  target_include_directories(boost_${name} PUBLIC include)
-  target_link_libraries(boost_${name} PUBLIC ${_boost_test_dependencies})
+  # Compiled targets
 
-  target_compile_definitions(boost_${name}
-    PUBLIC BOOST_TEST_NO_LIB
-    # Source files already define BOOST_TEST_SOURCE
-    # PRIVATE BOOST_TEST_SOURCE
+  function(boost_test_add_library name)
+
+    add_library(boost_${name} ${ARGN})
+    add_library(Boost::${name} ALIAS boost_${name})
+
+    target_include_directories(boost_${name} PUBLIC include)
+    target_link_libraries(boost_${name} PUBLIC ${_boost_test_dependencies})
+
+    target_compile_definitions(boost_${name}
+      PUBLIC BOOST_TEST_NO_LIB
+      # Source files already define BOOST_TEST_SOURCE
+      # PRIVATE BOOST_TEST_SOURCE
+    )
+
+    if(WIN32)
+      target_compile_definitions(boost_${name} PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_DYN_LINK)
+    else()
+      target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_STATIC_LINK)
+    endif()
+
+  endfunction()
+
+  boost_test_add_library(prg_exec_monitor
+    src/cpp_main.cpp
+    src/debug.cpp
+    src/execution_monitor.cpp
   )
 
-  if(WIN32)
-    target_compile_definitions(boost_${name} PRIVATE _CRT_SECURE_NO_WARNINGS)
-  endif()
+  set(SOURCES
+    src/compiler_log_formatter.cpp
+    src/debug.cpp
+    src/decorator.cpp
+    src/execution_monitor.cpp
+    src/framework.cpp
+    src/junit_log_formatter.cpp
+    src/plain_report_formatter.cpp
+    src/progress_monitor.cpp
+    src/results_collector.cpp
+    src/results_reporter.cpp
+    src/test_framework_init_observer.cpp
+    src/test_tools.cpp
+    src/test_tree.cpp
+    src/unit_test_log.cpp
+    src/unit_test_main.cpp
+    src/unit_test_monitor.cpp
+    src/unit_test_parameters.cpp
+    src/xml_log_formatter.cpp
+    src/xml_report_formatter.cpp
+  )
 
-  if(BUILD_SHARED_LIBS)
-    target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_DYN_LINK)
-  else()
-    target_compile_definitions(boost_${name} PUBLIC BOOST_TEST_STATIC_LINK)
-  endif()
+  boost_test_add_library(test_exec_monitor STATIC ${SOURCES} src/test_main.cpp)
+  boost_test_add_library(unit_test_framework ${SOURCES})
 
-endfunction()
+  set(_boost_test_libraries boost_prg_exec_monitor boost_test_exec_monitor boost_unit_test_framework)
 
-boost_test_add_library(prg_exec_monitor
-  src/cpp_main.cpp
-  src/debug.cpp
-  src/execution_monitor.cpp
-)
-
-set(SOURCES
-  src/compiler_log_formatter.cpp
-  src/debug.cpp
-  src/decorator.cpp
-  src/execution_monitor.cpp
-  src/framework.cpp
-  src/junit_log_formatter.cpp
-  src/plain_report_formatter.cpp
-  src/progress_monitor.cpp
-  src/results_collector.cpp
-  src/results_reporter.cpp
-  src/test_framework_init_observer.cpp
-  src/test_tools.cpp
-  src/test_tree.cpp
-  src/unit_test_log.cpp
-  src/unit_test_main.cpp
-  src/unit_test_monitor.cpp
-  src/unit_test_parameters.cpp
-  src/xml_log_formatter.cpp
-  src/xml_report_formatter.cpp
-)
-
-boost_test_add_library(test_exec_monitor STATIC ${SOURCES} src/test_main.cpp)
-boost_test_add_library(unit_test_framework ${SOURCES})
+endif()
 
 # Header-only targets
 
@@ -111,7 +121,7 @@ if(BOOST_SUPERPROJECT_VERSION AND NOT CMAKE_VERSION VERSION_LESS 3.13)
 
   boost_install(
     TARGETS
-      boost_prg_exec_monitor boost_test_exec_monitor boost_unit_test_framework
+      ${_boost_test_libraries}
       boost_included_prg_exec_monitor boost_included_test_exec_monitor boost_included_unit_test_framework
     VERSION ${BOOST_SUPERPROJECT_VERSION}
     HEADER_DIRECTORY include


### PR DESCRIPTION
This PR allows the build to be configured to install only the Boost.Test headers required for using the [headers-only variant](https://www.boost.org/doc/libs/1_88_0/libs/test/doc/html/boost_test/usage_variants.html#boost_test.usage_variants.single_header) of the Unit Test Framework.

The [`README.md`](https://github.com/boostorg/cmake/blob/develop/README.md) file at https://github.com/boostorg/cmake should also be updated to mention this new Boost.Test-specific configuration variable.