### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(_boost_test_dependencies
   Boost::optional
   Boost::preprocessor
   Boost::smart_ptr
-  Boost::static_assert
   Boost::type_traits
   Boost::utility
 )

--- a/build.jam
+++ b/build.jam
@@ -21,7 +21,6 @@ constant boost_dependencies :
     /boost/optional//boost_optional
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility ;
 

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -32,7 +32,6 @@ else()
       optional
       preprocessor
       smart_ptr
-      static_assert
       type_traits
       utility
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.