### PR TITLE
Add support for `std::optional`

### DIFF
--- a/include/boost/test/tools/detail/print_helper.hpp
+++ b/include/boost/test/tools/detail/print_helper.hpp
@@ -34,6 +34,9 @@
 #if !defined(BOOST_NO_CXX11_NULLPTR)
 #include <cstddef>
 #endif
+#if !defined(BOOST_NO_CXX17_HDR_OPTIONAL)
+#include <optional>
+#endif
 
 #include <boost/test/detail/suppress_warnings.hpp>
 
@@ -178,6 +181,26 @@ struct print_log_value<std::nullptr_t> {
     // declaration and definition is here because of #12969 https://svn.boost.org/trac10/ticket/12969
     void    operator()( std::ostream& ostr, std::nullptr_t /*t*/ ) {
         ostr << "nullptr";
+    }
+};
+#endif
+
+//____________________________________________________________________________//
+
+#if !defined(BOOST_NO_CXX17_HDR_OPTIONAL)
+template<typename T>
+struct print_log_value<std::optional<T>> {
+    void    operator()( std::ostream& ostr, std::optional<T> const& t ) {
+        if( t )
+            ostr << ' ' << *t;
+        else
+            ostr << "--";
+    }
+};
+template<>
+struct print_log_value<std::nullopt_t> {
+    void    operator()( std::ostream& ostr, std::nullopt_t /*t*/ ) {
+        ostr << "--";
     }
 };
 #endif

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -190,7 +190,7 @@ test-suite "writing-test-ts"
   # [ boost.test-self-test run-fail : writing-test-ts : test-timeout-fail : : : : : : [ requires cxx11_hdr_thread cxx11_hdr_chrono ] ]
   # [ boost.test-self-test run : writing-test-ts : test-timeout-suite : : : : : : $(requirements_datasets) [ requires cxx11_hdr_thread cxx11_hdr_chrono ] ]
   # [ boost.test-self-test run-fail : writing-test-ts : test-timeout-suite-fail : : : : : : $(requirements_datasets) [ requires cxx11_hdr_thread cxx11_hdr_chrono ] ]
-  [ boost.test-self-test run : writing-test-ts : github_issue_475 : : : : : : [ requires cxx17_hdr_optional ] ]
+  [ boost.test-self-test run : writing-test-ts : cxx17-optional-support : : : : : : [ requires cxx17_hdr_optional ] ]
 ;
 
 #_________________________________________________________________________________________________#

--- a/test/writing-test-ts/cxx17-optional-support.cpp
+++ b/test/writing-test-ts/cxx17-optional-support.cpp
@@ -2,14 +2,18 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#define BOOST_TEST_MODULE github_issue_475
+#define BOOST_TEST_MODULE cxx_std_optional_support
 #include <optional>
 #include <boost/test/unit_test.hpp>
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(std::optional<int>)
-
 BOOST_AUTO_TEST_CASE(test1)
 {
-    std::optional<int> a,b;
-    BOOST_TEST(a==b);
+    std::optional<int> a = 1, b = 2;
+    BOOST_TEST(a != b);
+}
+
+BOOST_AUTO_TEST_CASE(test2)
+{
+    std::optional<int> o;
+    BOOST_CHECK_EQUAL(o, std::nullopt);
 }


### PR DESCRIPTION
Output the same as for `boost::optional` and `boost::none_t`

Requires #490 